### PR TITLE
Refact ConfSelectorLammpsFrames

### DIFF
--- a/dpgen2/exploration/report/__init__.py
+++ b/dpgen2/exploration/report/__init__.py
@@ -4,3 +4,6 @@ from .report import (
 from .naive_report import (
     NaiveExplorationReport,
 )
+from .trajs_report import (
+    TrajsExplorationReport,
+)

--- a/dpgen2/exploration/report/trajs_report.py
+++ b/dpgen2/exploration/report/trajs_report.py
@@ -1,0 +1,116 @@
+import numpy as np
+import random
+from . import ExplorationReport
+from typing import (
+    List,
+    Tuple,
+)
+
+class TrajsExplorationReport(ExplorationReport):
+    def __init__(
+            self,
+    ):
+        self.clear()
+
+    def clear(
+            self,
+    ):
+        self.traj_nframes = []
+        self.traj_cand = []
+        self.traj_accu = []
+        self.traj_fail = []        
+        self.traj_cand_picked = []
+
+    def record_traj(
+            self,
+            id_f_accu,
+            id_f_cand,
+            id_f_fail,
+            id_v_accu,
+            id_v_cand,
+            id_v_fail,
+    ):
+        """
+        Record one trajctory. inputs are the indexes of candidate, accurate and failed frames. 
+
+        """
+        # check consistency
+        novirial = id_v_cand is None
+        if novirial:
+            assert(id_v_accu is None)
+            assert(id_v_fail is None)
+        nframes = np.size(np.concatenate((id_f_cand, id_f_accu, id_f_fail)))
+        if (not novirial) and nframes != np.size(np.concatenate((id_v_cand, id_v_accu, id_v_fail))):
+            raise FatalError("number of frames by virial ")
+        # nframes
+        # to sets
+        set_f_accu = set(id_f_accu)
+        set_f_cand = set(id_f_cand)
+        set_f_fail = set(id_f_fail)
+        set_v_accu = set([ii for ii in range(nframes)]) if novirial else set(id_v_accu)
+        set_v_cand = set([]) if novirial else set(id_v_cand)
+        set_v_fail = set([]) if novirial else set(id_v_fail)
+        # accu, cand, fail
+        set_accu = set_f_accu & set_v_accu
+        set_cand = ( (set_f_cand & set_v_accu) | 
+                     (set_f_cand & set_v_cand) | 
+                     (set_f_accu & set_v_cand) )
+        set_fail = ( set_f_fail | set_v_fail)
+        # check size
+        assert(nframes == len(set_accu | set_cand | set_fail))
+        assert(0 == len(set_accu & set_cand))
+        assert(0 == len(set_accu & set_fail))
+        assert(0 == len(set_cand & set_fail))
+        # record
+        self.traj_nframes.append(nframes)
+        self.traj_cand.append(set_cand)
+        self.traj_accu.append(set_accu)
+        self.traj_fail.append(set_fail)
+
+        
+    def failed_ratio(
+            self,
+            tag = None,
+    ):
+        traj_nf = [len(ii) for ii in self.traj_fail]
+        return float(traj_nf) / float(sum(self.traj_nframes))
+
+    def accurate_ratio(
+            self,
+            tag = None,
+    ):
+        traj_nf = [len(ii) for ii in self.traj_accu]
+        return float(traj_nf) / float(sum(self.traj_nframes))
+
+    def candidate_ratio(
+            self,
+            tag = None,
+    ):
+        traj_nf = [len(ii) for ii in self.traj_cand]
+        return float(traj_nf) / float(sum(self.traj_nframes))
+
+    def random_pick(
+            self,
+            pick_nframes : int,
+    )->List[Tuple[int,int]]:
+        """
+        Randomly pick `pick_nframes` frames from the candidates. 
+
+        Parameters
+        ----------
+        pick_nframes    int
+                The number of frames to pick
+
+        Returns
+        -------
+        picked_frames   List[Tuple[int,int]]
+                Picked frames. A list of tuples: [(traj_idx, frame_idx), ...]
+        """
+        self.traj_cand_picked = []
+        for tidx,tt in enumerate(self.traj_cand):
+            for ff in tt:
+                self.traj_cand_picked.append((tidx, ff))
+        random.shuffle(self.traj_cand_picked)
+        return self.traj_cand_picked[:pick_nframes]
+
+        

--- a/dpgen2/exploration/report/trajs_report.py
+++ b/dpgen2/exploration/report/trajs_report.py
@@ -73,44 +73,48 @@ class TrajsExplorationReport(ExplorationReport):
             tag = None,
     ):
         traj_nf = [len(ii) for ii in self.traj_fail]
-        return float(traj_nf) / float(sum(self.traj_nframes))
+        return float(sum(traj_nf)) / float(sum(self.traj_nframes))
 
     def accurate_ratio(
             self,
             tag = None,
     ):
         traj_nf = [len(ii) for ii in self.traj_accu]
-        return float(traj_nf) / float(sum(self.traj_nframes))
+        return float(sum(traj_nf)) / float(sum(self.traj_nframes))
 
     def candidate_ratio(
             self,
             tag = None,
     ):
         traj_nf = [len(ii) for ii in self.traj_cand]
-        return float(traj_nf) / float(sum(self.traj_nframes))
+        return float(sum(traj_nf)) / float(sum(self.traj_nframes))
 
-    def random_pick(
+    def get_candidates(
             self,
-            pick_nframes : int,
+            max_nframes : int = None,
     )->List[Tuple[int,int]]:
         """
-        Randomly pick `pick_nframes` frames from the candidates. 
+        Get candidates. If number of candidates is larger than `max_nframes`, 
+        then randomly pick `max_nframes` frames from the candidates. 
 
         Parameters
         ----------
-        pick_nframes    int
-                The number of frames to pick
+        max_nframes    int
+                The maximal number of frames of candidates.
 
         Returns
         -------
-        picked_frames   List[Tuple[int,int]]
-                Picked frames. A list of tuples: [(traj_idx, frame_idx), ...]
+        cand_frames   List[Tuple[int,int]]
+                Candidate frames. A list of tuples: [(traj_idx, frame_idx), ...]
         """
         self.traj_cand_picked = []
         for tidx,tt in enumerate(self.traj_cand):
             for ff in tt:
                 self.traj_cand_picked.append((tidx, ff))
-        random.shuffle(self.traj_cand_picked)
-        return self.traj_cand_picked[:pick_nframes]
-
+        if max_nframes and max_nframes < len(self.traj_cand_picked):
+            random.shuffle(self.traj_cand_picked)
+            ret = sorted(self.traj_cand_picked[:max_nframes])
+        else:
+            ret = self.traj_cand_picked
+        return ret
         

--- a/tests/exploration/test_conf_selector_frame.py
+++ b/tests/exploration/test_conf_selector_frame.py
@@ -90,9 +90,12 @@ class TestConfSelectorLammpsFrames(unittest.TestCase):
         self.assertAlmostEqual(ss['coords'][3][0][1], 2.87, places=2)
         self.assertAlmostEqual(ss['coords'][4][0][1], 3.87, places=2)
         self.assertAlmostEqual(ss['coords'][5][0][1], 4.87, places=2)
-        self.assertAlmostEqual(report.ratio('force', 'candidate'), 1.)
-        self.assertAlmostEqual(report.ratio('force', 'accurate'), 0.)
-        self.assertAlmostEqual(report.ratio('force', 'failed'), 0.)
+        # self.assertAlmostEqual(report.ratio('force', 'candidate'), 1.)
+        # self.assertAlmostEqual(report.ratio('force', 'accurate'), 0.)
+        # self.assertAlmostEqual(report.ratio('force', 'failed'), 0.)
+        self.assertAlmostEqual(report.candidate_ratio(), 1.)
+        self.assertAlmostEqual(report.accurate_ratio(), 0.)
+        self.assertAlmostEqual(report.failed_ratio(), 0.)
 
     def test_f_1(self):
         conf_selector = ConfSelectorLammpsFrames(
@@ -107,9 +110,13 @@ class TestConfSelectorLammpsFrames(unittest.TestCase):
         self.assertEqual(ss.get_nframes(), 2)
         self.assertAlmostEqual(ss['coords'][0][0][1], 3.87, places=2)
         self.assertAlmostEqual(ss['coords'][1][0][1], 3.87, places=2)
-        self.assertAlmostEqual(report.ratio('force', 'candidate'), 1./3.)
-        self.assertAlmostEqual(report.ratio('force', 'accurate'), 1./3.)
-        self.assertAlmostEqual(report.ratio('force', 'failed'), 1./3.)
+        # self.assertAlmostEqual(report.ratio('force', 'candidate'), 1./3.)
+        # self.assertAlmostEqual(report.ratio('force', 'accurate'), 1./3.)
+        # self.assertAlmostEqual(report.ratio('force', 'failed'), 1./3.)
+        self.assertAlmostEqual(report.candidate_ratio(), 1./3.)
+        self.assertAlmostEqual(report.accurate_ratio(), 1./3.)
+        self.assertAlmostEqual(report.failed_ratio(), 1./3.)
+        
 
     def test_fv_0(self):
         conf_selector = ConfSelectorLammpsFrames(
@@ -121,16 +128,33 @@ class TestConfSelectorLammpsFrames(unittest.TestCase):
         ms.from_deepmd_npy(confs[0], labeled=False)
         self.assertEqual(len(ms), 1)
         ss = ms[0]
-        self.assertEqual(ss.get_nframes(), 4)
+        self.assertEqual(ss.get_nframes(), 2)
         self.assertAlmostEqual(ss['coords'][0][0][1], 2.87, places=2)
-        self.assertAlmostEqual(ss['coords'][1][0][1], 3.87, places=2)
-        self.assertAlmostEqual(ss['coords'][2][0][1], 2.87, places=2)
-        self.assertAlmostEqual(ss['coords'][3][0][1], 3.87, places=2)
-        self.assertAlmostEqual(report.ratio('force', 'candidate'), 1./3.)
-        self.assertAlmostEqual(report.ratio('force', 'accurate'), 1./3.)
-        self.assertAlmostEqual(report.ratio('force', 'failed'), 1./3.)
-        self.assertAlmostEqual(report.ratio('virial', 'candidate'), 1./3.)
-        self.assertAlmostEqual(report.ratio('virial', 'accurate'), 0.)
-        self.assertAlmostEqual(report.ratio('virial', 'failed'), 2./3.)
-
+        self.assertAlmostEqual(ss['coords'][1][0][1], 2.87, places=2)
+        # self.assertAlmostEqual(report.ratio('force', 'candidate'), 1./3.)
+        # self.assertAlmostEqual(report.ratio('force', 'accurate'), 1./3.)
+        # self.assertAlmostEqual(report.ratio('force', 'failed'), 1./3.)
+        # self.assertAlmostEqual(report.ratio('virial', 'candidate'), 1./3.)
+        # self.assertAlmostEqual(report.ratio('virial', 'accurate'), 0.)
+        # self.assertAlmostEqual(report.ratio('virial', 'failed'), 2./3.)
+        self.assertAlmostEqual(report.candidate_ratio(), 1./3.)
+        self.assertAlmostEqual(report.accurate_ratio(), 0./3.)
+        self.assertAlmostEqual(report.failed_ratio(), 2./3.)
+        
+    def test_fv_1(self):
+        conf_selector = ConfSelectorLammpsFrames(
+            TrustLevel(0.25, 0.35, 0.05, 0.15),
+            max_numb_sel = 1,
+        )
+        confs, report = conf_selector.select(
+            self.trajs, self.model_devis, self.traj_fmt, self.type_map)
+        ms = dpdata.MultiSystems()
+        ms.from_deepmd_npy(confs[0], labeled=False)
+        self.assertEqual(len(ms), 1)
+        ss = ms[0]
+        self.assertEqual(ss.get_nframes(), 1)
+        self.assertAlmostEqual(ss['coords'][0][0][1], 2.87, places=2)
+        self.assertAlmostEqual(report.candidate_ratio(), 1./3.)
+        self.assertAlmostEqual(report.accurate_ratio(), 0./3.)
+        self.assertAlmostEqual(report.failed_ratio(), 2./3.)
         

--- a/tests/exploration/test_report.py
+++ b/tests/exploration/test_report.py
@@ -3,7 +3,7 @@ import os, textwrap
 import numpy as np
 import unittest
 from collections import Counter
-from dpgen2.exploration.report import NaiveExplorationReport
+from dpgen2.exploration.report import NaiveExplorationReport, TrajsExplorationReport
 
 class TestNaiveExplorationReport(unittest.TestCase):
     def test_naive_fv(self):
@@ -64,3 +64,65 @@ class TestNaiveExplorationReport(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             report.ratio('force', 'bar')
         self.assertTrue('invalid item bar' in str(context.exception))
+
+
+class TestTrajsExplorationResport(unittest.TestCase):
+    def test_fv(self):
+        id_f_accu = [ [3, 5, 1], [1, 7, 5] ]
+        id_f_cand = [ [4, 7, 6], [8, 6, 0] ]
+        id_f_fail = [ [2, 0, 8], [4, 2, 3] ]
+        id_v_accu = [ [1, 2, 6], [7, 8, 6] ]
+        id_v_cand = [ [0, 5, 8], [0, 5, 4] ]
+        id_v_fail = [ [4, 3, 7], [2, 3, 1] ]
+        expected_accu = [ [1], [7] ]
+        expected_cand = [ [6, 5], [8, 6, 0, 5] ]
+        expected_fail = [ [0, 2, 3, 4, 7, 8], [1, 2, 3, 4] ]
+        expected_accu = [set(ii) for ii in expected_accu]
+        expected_cand = [set(ii) for ii in expected_cand]
+        expected_fail = [set(ii) for ii in expected_fail]
+        all_cand_sel = [ (0,6), (0,5), (1,8), (1,6), (1,0), (1,5) ]
+        
+        ter = TrajsExplorationReport()
+        for ii in range(2):
+            ter.record_traj(
+                id_f_accu[ii], id_f_cand[ii], id_f_fail[ii],
+                id_v_accu[ii], id_v_cand[ii], id_v_fail[ii],
+            )
+        self.assertEqual(ter.traj_cand, expected_cand)
+        self.assertEqual(ter.traj_accu, expected_accu)
+        self.assertEqual(ter.traj_fail, expected_fail)
+        
+        picked = ter.random_pick(2)
+        self.assertEqual(len(picked), 2)
+        self.assertTrue(picked[0] in all_cand_sel)
+        self.assertTrue(picked[1] in all_cand_sel)
+
+    def test_f(self):
+        id_f_accu = [ [3, 5, 1], [1, 7, 5] ]
+        id_f_cand = [ [4, 7, 6], [8, 6, 0] ]
+        id_f_fail = [ [2, 0, 8], [4, 2, 3] ]
+        id_v_accu = [None, None]
+        id_v_cand = [None, None]
+        id_v_fail = [None, None]
+        expected_accu = id_f_accu
+        expected_cand = id_f_cand
+        expected_fail = id_f_fail
+        expected_accu = [set(ii) for ii in expected_accu]
+        expected_cand = [set(ii) for ii in expected_cand]
+        expected_fail = [set(ii) for ii in expected_fail]
+        all_cand_sel = [ (0,4), (0,7), (0,6), (1,6), (1,0), (1,8) ]
+        
+        ter = TrajsExplorationReport()
+        for ii in range(2):
+            ter.record_traj(
+                id_f_accu[ii], id_f_cand[ii], id_f_fail[ii],
+                id_v_accu[ii], id_v_cand[ii], id_v_fail[ii],
+            )
+        self.assertEqual(ter.traj_cand, expected_cand)
+        self.assertEqual(ter.traj_accu, expected_accu)
+        self.assertEqual(ter.traj_fail, expected_fail)
+        
+        picked = ter.random_pick(2)
+        self.assertEqual(len(picked), 2)
+        self.assertTrue(picked[0] in all_cand_sel)
+        self.assertTrue(picked[1] in all_cand_sel)

--- a/tests/exploration/test_report.py
+++ b/tests/exploration/test_report.py
@@ -92,10 +92,14 @@ class TestTrajsExplorationResport(unittest.TestCase):
         self.assertEqual(ter.traj_accu, expected_accu)
         self.assertEqual(ter.traj_fail, expected_fail)
         
-        picked = ter.random_pick(2)
+        picked = ter.get_candidates(2)
         self.assertEqual(len(picked), 2)
         self.assertTrue(picked[0] in all_cand_sel)
         self.assertTrue(picked[1] in all_cand_sel)
+        self.assertEqual(ter.candidate_ratio(), 6./18.)
+        self.assertEqual(ter.accurate_ratio(), 2./18.)
+        self.assertEqual(ter.failed_ratio(), 10./18.)
+
 
     def test_f(self):
         id_f_accu = [ [3, 5, 1], [1, 7, 5] ]
@@ -122,7 +126,40 @@ class TestTrajsExplorationResport(unittest.TestCase):
         self.assertEqual(ter.traj_accu, expected_accu)
         self.assertEqual(ter.traj_fail, expected_fail)
         
-        picked = ter.random_pick(2)
+        picked = ter.get_candidates(2)
         self.assertEqual(len(picked), 2)
         self.assertTrue(picked[0] in all_cand_sel)
         self.assertTrue(picked[1] in all_cand_sel)
+
+
+    def test_f_max(self):
+        id_f_accu = [ [3, 5, 1], [1, 7, 5] ]
+        id_f_cand = [ [4, 7, 6], [8, 6, 0] ]
+        id_f_fail = [ [2, 0, 8], [4, 2, 3] ]
+        id_v_accu = [None, None]
+        id_v_cand = [None, None]
+        id_v_fail = [None, None]
+        expected_accu = id_f_accu
+        expected_cand = id_f_cand
+        expected_fail = id_f_fail
+        expected_accu = [set(ii) for ii in expected_accu]
+        expected_cand = [set(ii) for ii in expected_cand]
+        expected_fail = [set(ii) for ii in expected_fail]
+        all_cand_sel = [ (0,4), (0,7), (0,6), (1,6), (1,0), (1,8) ]
+        
+        ter = TrajsExplorationReport()
+        for ii in range(2):
+            ter.record_traj(
+                id_f_accu[ii], id_f_cand[ii], id_f_fail[ii],
+                id_v_accu[ii], id_v_cand[ii], id_v_fail[ii],
+            )
+        self.assertEqual(ter.traj_cand, expected_cand)
+        self.assertEqual(ter.traj_accu, expected_accu)
+        self.assertEqual(ter.traj_fail, expected_fail)
+        
+        picked = ter.get_candidates(10)
+        self.assertEqual(len(picked), 6)
+        self.assertEqual(
+            set(picked),
+            set(all_cand_sel),
+        )


### PR DESCRIPTION
1. implement trajectory report `TrajsExplorationReport`. record all accurate, candidate, and failed frames. make selection
2. refact the `ConfSelectorLammpsFrames` by using the `TrajsExplorationReport`