### PR TITLE
Fix bugs: running lmp and loading traj in conf selection

### DIFF
--- a/dpgen2/exploration/selector/conf_selector_frame.py
+++ b/dpgen2/exploration/selector/conf_selector_frame.py
@@ -80,9 +80,10 @@ class ConfSelectorLammpsFrames(ConfSelector):
 
         ms = dpdata.MultiSystems()
         for ii in range(ntraj):
-            ss = dpdata.System(trajs[ii], fmt=traj_fmt, type_map=type_map)
-            ss = ss.sub_system(id_cand_list[ii])        
-            ms.append(ss)
+            if len(id_cand_list[ii]) > 0:
+                ss = dpdata.System(trajs[ii], fmt=traj_fmt, type_map=type_map)
+                ss = ss.sub_system(id_cand_list[ii])        
+                ms.append(ss)
             
         out_path = Path('confs')
         ms.to_deepmd_npy(out_path)

--- a/dpgen2/exploration/task/lmp/lmp_input.py
+++ b/dpgen2/exploration/task/lmp/lmp_input.py
@@ -6,7 +6,9 @@ from typing import (
 from distutils.version import (
     LooseVersion,
 )
-
+from dpgen2.constants import (
+    lmp_traj_name,
+)
 
 def _sample_sphere() :
     while True:
@@ -96,14 +98,14 @@ def make_lmp_input(
         if ele_temp_a is not None:
             keywords += "aparam ${ELE_TEMP}"
         ret+= "pair_style      deepmd %s out_freq ${THERMO_FREQ} out_file model_devi.out %s\n" % (graph_list, keywords)
-    ret+= "pair_coeff      \n"
+    ret+= "pair_coeff      * *\n"
     ret+= "\n"
     ret+= "thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz\n"
     ret+= "thermo          ${THERMO_FREQ}\n"
     if trj_seperate_files:        
         ret+= "dump            1 all custom ${DUMP_FREQ} traj/*.lammpstrj id type x y z fx fy fz\n"
     else:
-        ret+= "dump            1 all custom ${DUMP_FREQ} dump.traj id type x y z fx fy fz\n"
+        ret+= "dump            1 all custom ${DUMP_FREQ} %s id type x y z fx fy fz\n" % lmp_traj_name
     ret+= "restart         10000 dpgen.restart\n"
     ret+= "\n"
     if pka_e is None :

--- a/dpgen2/exploration/task/npt_task_group.py
+++ b/dpgen2/exploration/task/npt_task_group.py
@@ -167,6 +167,7 @@ class NPTTaskGroup(ExplorationTaskGroup):
                     self.ele_temp_f,
                     self.ele_temp_a,
                     self.no_pbc,
+                    trj_seperate_files = False,
                 )
             )
         return task

--- a/dpgen2/op/run_lmp.py
+++ b/dpgen2/op/run_lmp.py
@@ -30,6 +30,7 @@ from dargs import (
     ArgumentEncoder,
 )
 
+
 class RunLmp(OP):
     r"""Execute a LAMMPS task.
 
@@ -109,8 +110,8 @@ class RunLmp(OP):
                 mname = model_name_pattern % (idx)
                 Path(mname).symlink_to(mm)
             # run lmp
-            command = [command, '-i', lmp_input_name, '-log', lmp_log_name]
-            ret, out, err = run_command(command)
+            command = ' '.join([command, '-i', lmp_input_name, '-log', lmp_log_name])
+            ret, out, err = run_command(command, shell=True)
             if ret != 0:
                 raise TransientError(
                     'lmp failed\n',

--- a/tests/exploration/test_exploration_group.py
+++ b/tests/exploration/test_exploration_group.py
@@ -40,7 +40,7 @@ pair_coeff      * *
 
 thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz
 thermo          ${THERMO_FREQ}
-dump            1 all custom ${DUMP_FREQ} traj/*.lammpstrj id type x y z fx fy fz
+dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z fx fy fz
 restart         10000 dpgen.restart
 
 if "${restart} == 0" then "velocity        all create ${TEMP} 1111"
@@ -72,7 +72,7 @@ pair_coeff      * *
 
 thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz
 thermo          ${THERMO_FREQ}
-dump            1 all custom ${DUMP_FREQ} traj/*.lammpstrj id type x y z fx fy fz
+dump            1 all custom ${DUMP_FREQ} traj.dump id type x y z fx fy fz
 restart         10000 dpgen.restart
 
 if "${restart} == 0" then "velocity        all create ${TEMP} 1111"

--- a/tests/exploration/test_exploration_group.py
+++ b/tests/exploration/test_exploration_group.py
@@ -36,7 +36,7 @@ change_box   all triclinic
 mass            1 10.000000
 mass            2 20.000000
 pair_style      deepmd model.000.pb model.001.pb model.002.pb  out_freq ${THERMO_FREQ} out_file model_devi.out 
-pair_coeff      
+pair_coeff      * *
 
 thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz
 thermo          ${THERMO_FREQ}
@@ -68,7 +68,7 @@ change_box   all triclinic
 mass            1 10.000000
 mass            2 20.000000
 pair_style      deepmd model.000.pb model.001.pb model.002.pb  out_freq ${THERMO_FREQ} out_file model_devi.out 
-pair_coeff      
+pair_coeff      * *
 
 thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz
 thermo          ${THERMO_FREQ}

--- a/tests/op/test_run_lmp.py
+++ b/tests/op/test_run_lmp.py
@@ -60,7 +60,7 @@ class TestRunLmp(unittest.TestCase):
         self.assertEqual(out['model_devi'], work_dir/lmp_model_devi_name)
         # check call
         calls = [
-            call(['mylmp', '-i', lmp_input_name, '-log', lmp_log_name]),
+            call(' '.join(['mylmp', '-i', lmp_input_name, '-log', lmp_log_name]), shell=True),
         ]
         mocked_run.assert_has_calls(calls)
         # check input files are correctly linked
@@ -84,7 +84,7 @@ class TestRunLmp(unittest.TestCase):
                 }))
         # check call
         calls = [
-            call(['mylmp', '-i', lmp_input_name, '-log', lmp_log_name]),
+            call(' '.join(['mylmp', '-i', lmp_input_name, '-log', lmp_log_name]), shell=True),
         ]
         mocked_run.assert_has_calls(calls)
                         


### PR DESCRIPTION
1. [load traj only when at least one frame is selected](https://github.com/deepmodeling/dpgen2/commit/cee324f43fd3cae099721df3efe53a2688760a62)
2. [fix lammps related bugs:](https://github.com/deepmodeling/dpgen2/commit/181b0f9a47e4a5eff48afea74245174af6de7f98)
    1. name of traj file. 
    2. pair_coeff * *
    3. lmp command line should set the restart variable, use shell mode in Popen