### PR TITLE
fix type hints errors; add type checker

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+  pull_request:
+name: Type checker
+jobs:
+  test:
+    name: pyright
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - run: pip install -e .
+    - uses: jakebailey/pyright-action@v1

--- a/dpgen2/entrypoint/download.py
+++ b/dpgen2/entrypoint/download.py
@@ -28,6 +28,7 @@ def download(
     if wf_keys is None:
         wf_keys = wf.query_keys_of_steps()
     
+    assert wf_keys is not None
     for kk in wf_keys:
         download_dpgen2_artifacts(wf, kk, prefix=prefix)
         logging.info(f'step {kk} downloaded')

--- a/dpgen2/entrypoint/submit.py
+++ b/dpgen2/entrypoint/submit.py
@@ -102,16 +102,16 @@ def make_concurrent_learning_op (
         train_style : str = 'dp',
         explore_style : str = 'lmp',
         fp_style : str = 'vasp',
-        prep_train_config : str = default_config,
-        run_train_config : str = default_config,
-        prep_explore_config : str = default_config,
-        run_explore_config : str = default_config,
-        prep_fp_config : str = default_config,
-        run_fp_config : str = default_config,
-        select_confs_config : str = default_config,
-        collect_data_config : str = default_config,
-        cl_step_config : str = default_config,
-        upload_python_package : bool = None,
+        prep_train_config : dict = default_config,
+        run_train_config : dict = default_config,
+        prep_explore_config : dict = default_config,
+        run_explore_config : dict = default_config,
+        prep_fp_config : dict = default_config,
+        run_fp_config : dict = default_config,
+        select_confs_config : dict = default_config,
+        collect_data_config : dict = default_config,
+        cl_step_config : dict = default_config,
+        upload_python_package : Optional[List[os.PathLike]] = None,
 ):
     if train_style == 'dp':
         prep_run_train_op = PrepRunDPTrain(
@@ -277,6 +277,8 @@ def get_kspacing_kgamma_from_incar(
 ):
     with open(fname) as fp:
         lines = fp.readlines()
+    ks = None
+    kg = None
     for ii in lines:
         if 'KSPACING' in ii:
             ks = float(ii.split('=')[1])
@@ -287,12 +289,13 @@ def get_kspacing_kgamma_from_incar(
                 kg = False
             else:
                 raise RuntimeError(f"invalid kgamma value {ii.split('=')[1]}")
+    assert ks is not None and kg is not None
     return ks, kg
 
 
 def workflow_concurrent_learning(
         config : Dict,
-        old_style : Optional[bool] = False,
+        old_style : bool = False,
 ):
     default_config = normalize_step_dict(config.get('default_config', {})) if old_style else config['default_step_config']
 

--- a/dpgen2/entrypoint/watch.py
+++ b/dpgen2/entrypoint/watch.py
@@ -24,7 +24,7 @@ default_watching_keys = [
 
 def update_finished_steps(
         wf,
-        finished_keys : List[str] = None,
+        finished_keys : Optional[List[str]] = None,
         download : Optional[bool] = False,
         watching_keys : Optional[List[str]] = None,
         prefix : Optional[str] = None,
@@ -51,7 +51,7 @@ def watch(
         workflow_id,
         wf_config : Optional[Dict] = {},
         watching_keys : Optional[List] = default_watching_keys,
-        frequency : Optional[float] = 600.,
+        frequency : float = 600.,
         download : Optional[bool] = False,
         prefix : Optional[str] = None,
 ):

--- a/dpgen2/exploration/report/trajs_report.py
+++ b/dpgen2/exploration/report/trajs_report.py
@@ -3,7 +3,11 @@ import random
 from . import ExplorationReport
 from typing import (
     List,
+    Optional,
     Tuple,
+)
+from dflow.python import (
+    FatalError,
 )
 
 class TrajsExplorationReport(ExplorationReport):
@@ -91,7 +95,7 @@ class TrajsExplorationReport(ExplorationReport):
 
     def get_candidates(
             self,
-            max_nframes : int = None,
+            max_nframes : Optional[int] = None,
     )->List[Tuple[int,int]]:
         """
         Get candidates. If number of candidates is larger than `max_nframes`, 

--- a/dpgen2/exploration/scheduler/convergence_check_stage_scheduler.py
+++ b/dpgen2/exploration/scheduler/convergence_check_stage_scheduler.py
@@ -1,5 +1,6 @@
 from typing import (
     List,
+    Optional,
     Tuple,
 )
 from dflow.python import (
@@ -17,7 +18,7 @@ class ConvergenceCheckStageScheduler(StageScheduler):
             stage : ExplorationStage,
             selector : ConfSelector,
             conv_accuracy : float = 0.9,
-            max_numb_iter : int = None,
+            max_numb_iter : Optional[int] = None,
             fatal_at_max : bool = True,
     ):
         self.stage = stage
@@ -42,9 +43,9 @@ class ConvergenceCheckStageScheduler(StageScheduler):
 
     def plan_next_iteration(
             self,
-            report : ExplorationReport = None,
-            trajs : List[Path] = None,
-    ) -> Tuple[bool, ExplorationTaskGroup, ConfSelector] :
+            report : Optional[ExplorationReport] = None,
+            trajs : Optional[List[Path]] = None,
+    ) -> Tuple[bool, Optional[ExplorationTaskGroup], Optional[ConfSelector]] :
         if report is None:
             stg_complete = False
             self.conv = stg_complete

--- a/dpgen2/exploration/scheduler/scheduler.py
+++ b/dpgen2/exploration/scheduler/scheduler.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from typing import (
     List,
+    Optional,
     Tuple,
 )
 from dflow.python import (
@@ -76,9 +77,9 @@ class ExplorationScheduler():
 
     def plan_next_iteration(
             self,
-            report : ExplorationReport = None,
-            trajs : List[Path] = None,
-    ) -> Tuple[bool, ExplorationTaskGroup, ConfSelector] :
+            report : Optional[ExplorationReport] = None,
+            trajs : Optional[List[Path]] = None,
+    ) -> Tuple[bool, Optional[ExplorationTaskGroup], Optional[ConfSelector]] :
         """
         Make the plan for the next DPGEN iteration.
 
@@ -202,7 +203,9 @@ class ExplorationScheduler():
         for iidx in range(len(accu)):
             if stage_idx[iidx] != prev_stg_idx:
                 if prev_stg_idx >= 0:
-                    ret.append(self._print_prev_summary(prev_stg_idx))
+                    _summary = self._print_prev_summary(prev_stg_idx)
+                    assert _summary is not None
+                    ret.append(_summary)
                 ret.append(f'# Stage {stage_idx[iidx]:4d}  ' + '-'*20)
                 prev_stg_idx = stage_idx[iidx]
             ret.append(' ' + fmt_str % (
@@ -213,6 +216,8 @@ class ExplorationScheduler():
             ))
         if self.complete():
             if prev_stg_idx >= 0:
-                ret.append(self._print_prev_summary(prev_stg_idx))
+                _summary = self._print_prev_summary(prev_stg_idx)
+                assert _summary is not None
+                ret.append(_summary)
                 ret.append(f'# All stages converged')
         return '\n'.join(ret + [''])

--- a/dpgen2/exploration/selector/conf_filter.py
+++ b/dpgen2/exploration/selector/conf_filter.py
@@ -7,9 +7,9 @@ class ConfFilter(ABC):
     @abstractmethod
     def check (
             self,
-            coords : np.array,
-            cell: np.array,
-            atom_types : np.array,
+            coords : np.ndarray,
+            cell: np.ndarray,
+            atom_types : np.ndarray,
             nopbc: bool,
     ) -> bool :
         """Check if the configuration is valid.

--- a/dpgen2/exploration/selector/conf_selector.py
+++ b/dpgen2/exploration/selector/conf_selector.py
@@ -1,6 +1,6 @@
 import dpdata
 from abc import ABC, abstractmethod
-from typing import Tuple, List, Set
+from typing import Optional, Tuple, List, Set
 from pathlib import Path
 from . import (
     ConfFilters,
@@ -17,7 +17,7 @@ class ConfSelector(ABC):
             trajs : List[Path],
             model_devis : List[Path],
             traj_fmt : str = 'deepmd/npy',
-            type_map : List[str] = None,
+            type_map : Optional[List[str]] = None,
     ) -> Tuple[List[ Path ], ExplorationReport]:
         pass
 

--- a/dpgen2/exploration/selector/conf_selector_frame.py
+++ b/dpgen2/exploration/selector/conf_selector_frame.py
@@ -3,6 +3,7 @@ import numpy as np
 from collections import Counter
 from typing import (
     List,
+    Optional,
     Tuple,
 )
 from pathlib import Path
@@ -25,8 +26,8 @@ class ConfSelectorLammpsFrames(ConfSelector):
     def __init__(
             self,
             trust_level,
-            max_numb_sel : int = None,
-            conf_filters : ConfFilters = None,
+            max_numb_sel : Optional[int] = None,
+            conf_filters : Optional[ConfFilters] = None,
     ):
         self.trust_level = trust_level
         self.max_numb_sel = max_numb_sel
@@ -38,7 +39,7 @@ class ConfSelectorLammpsFrames(ConfSelector):
             trajs : List[Path],
             model_devis : List[Path],
             traj_fmt : str = 'lammps/dump',
-            type_map : List[str] = None,
+            type_map : Optional[List[str]] = None,
     ) -> Tuple[List[ Path ], ExplorationReport]:
         """Select configurations
 
@@ -136,6 +137,6 @@ class ConfSelectorLammpsFrames(ConfSelector):
     @staticmethod
     def _load_model_devi(
             fname : Path,
-    ) -> Tuple[np.array, np.array] : 
+    ) -> Tuple[np.ndarray, np.ndarray] : 
         dd = np.loadtxt(fname)
         return dd[:,4], dd[:,1]

--- a/dpgen2/exploration/task/conf_sampling_task_group.py
+++ b/dpgen2/exploration/task/conf_sampling_task_group.py
@@ -1,6 +1,7 @@
 import itertools, random
 from typing import (
     List,
+    Optional,
 )
 from . import (
     ExplorationTask,
@@ -22,7 +23,7 @@ class ConfSamplingTaskGroup(ExplorationTaskGroup):
     def set_conf(
             self,
             conf_list : List[str],
-            n_sample : int = None,
+            n_sample : Optional[int] = None,
             random_sample : bool = False,
     ):
         """

--- a/dpgen2/exploration/task/lmp/lmp_input.py
+++ b/dpgen2/exploration/task/lmp/lmp_input.py
@@ -2,6 +2,7 @@ import random
 import numpy as np
 from typing import (
     List,
+    Optional,
 )
 from distutils.version import (
     LooseVersion,
@@ -9,6 +10,9 @@ from distutils.version import (
 from dpgen2.constants import (
     lmp_traj_name,
 )
+
+import dpdata
+import scipy.constants as pc
 
 def _sample_sphere() :
     while True:
@@ -24,19 +28,19 @@ def make_lmp_input(
         graphs : List[str],
         nsteps : int,
         dt : float,
-        neidelay : int,
+        neidelay : Optional[int],
         trj_freq : int,
         mass_map : List[float],
         temp : float, 
         tau_t : float = 0.1,
-        pres : float= None,
+        pres : Optional[float]= None,
         tau_p : float = 0.5,
         use_clusters : bool = False,        
-        relative_f_epsilon : float = None,
-        relative_v_epsilon : float = None,
-        pka_e : float = None,
-        ele_temp_f : float = None,
-        ele_temp_a : float = None,
+        relative_f_epsilon : Optional[float] = None,
+        relative_v_epsilon : Optional[float] = None,
+        pka_e : Optional[float] = None,
+        ele_temp_f : Optional[float] = None,
+        ele_temp_a : Optional[float] = None,
         nopbc : bool = False,
         max_seed : int = 1000000,
         deepmd_version = '2.0', 
@@ -115,7 +119,7 @@ def make_lmp_input(
         sys_data = sys.data
         pka_mass = mass_map[sys_data['atom_types'][0] - 1]
         pka_vn = pka_e * pc.electron_volt / \
-                 (0.5 * pka_mass * 1e-3 / pc.Avogadro * (pc.angstrom / pc.pico) ** 2)
+                 (0.5 * pka_mass * 1e-3 / pc.Avogadro * (pc.angstrom / pc.pico) ** 2) # type: ignore
         pka_vn = np.sqrt(pka_vn)
         print(pka_vn)
         pka_vec = _sample_sphere()

--- a/dpgen2/exploration/task/lmp_template_task_group.py
+++ b/dpgen2/exploration/task/lmp_template_task_group.py
@@ -1,6 +1,7 @@
 import itertools, random
 from typing import (
     List,
+    Optional,
 )
 from pathlib import Path
 from . import (
@@ -30,7 +31,7 @@ class LmpTemplateTaskGroup(ConfSamplingTaskGroup):
             self,
             numb_models : int,
             lmp_template_fname : str,
-            plm_template_fname : str = None,
+            plm_template_fname : Optional[str] = None,
             revisions : dict = {},
             traj_freq : int = 10,
     )->None:
@@ -92,7 +93,7 @@ class LmpTemplateTaskGroup(ConfSamplingTaskGroup):
             self,
             conf: str,
             lmp_cont : str,
-            plm_cont : str = None,
+            plm_cont : Optional[str] = None,
     )->ExplorationTask:
         task = ExplorationTask()
         task\

--- a/dpgen2/exploration/task/npt_task_group.py
+++ b/dpgen2/exploration/task/npt_task_group.py
@@ -1,6 +1,7 @@
 import itertools, random
 from typing import (
     List,
+    Optional,
 )
 from . import (
     ExplorationTask,
@@ -26,21 +27,21 @@ class NPTTaskGroup(ConfSamplingTaskGroup):
             numb_models,
             mass_map,
             temps : List[float],
-            press : List[float] = None,
+            press : Optional[List[float]] = None,
             ens : str = 'npt',
             dt : float = 0.001,
             nsteps : int = 1000,
             trj_freq : int = 10,
             tau_t : float = 0.1,
             tau_p : float = 0.5,
-            pka_e : float = None,
-            neidelay : int = None,
+            pka_e : Optional[float] = None,
+            neidelay : Optional[int] = None,
             no_pbc : bool = False,
             use_clusters : bool = False,
-            relative_f_epsilon : float = None,
-            relative_v_epsilon : float = None,
-            ele_temp_f : float = None,
-            ele_temp_a : float = None,
+            relative_f_epsilon : Optional[float] = None,
+            relative_v_epsilon : Optional[float] = None,
+            ele_temp_f : Optional[float] = None,
+            ele_temp_a : Optional[float] = None,
     ):
         """
         Set MD parameters
@@ -95,7 +96,7 @@ class NPTTaskGroup(ConfSamplingTaskGroup):
             self,
             conf : str,
             tt : float,
-            pp : float,
+            pp : Optional[float],
     ) -> ExplorationTask:
         task = ExplorationTask()
         task\

--- a/dpgen2/exploration/task/task.py
+++ b/dpgen2/exploration/task/task.py
@@ -122,7 +122,8 @@ class FooTask(ExplorationTask):
 class FooTaskGroup(ExplorationTaskGroup):
     def __init__(self, numb_task):
         super().__init__()
-        self.tlist = []
+        # TODO: confirm the following is correct
+        self.tlist = ExplorationTaskGroup()
         for ii in range(numb_task):
             self.tlist.add_task( 
                 FooTask(f'conf.{ii}', f'this is conf.{ii}',

--- a/dpgen2/flow/dpgen_loop.py
+++ b/dpgen2/flow/dpgen_loop.py
@@ -27,7 +27,8 @@ from dflow.python import(
 )
 import pickle, jsonpickle, os
 from typing import (
-    List
+    List,
+    Optional,
 )
 from pathlib import Path
 from dpgen2.exploration.scheduler import ExplorationScheduler
@@ -117,7 +118,7 @@ class ConcurrentLearningLoop(Steps):
             name : str,
             block_op : OPTemplate,
             step_config : dict = normalize_step_dict({}),
-            upload_python_package : str = None,
+            upload_python_package : Optional[List[os.PathLike]] = None,
     ):
         self._input_parameters={
             "block_id" : InputParameter(),
@@ -203,7 +204,7 @@ class ConcurrentLearning(Steps):
             name : str,
             block_op : OPTemplate,
             step_config : dict = normalize_step_dict({}),
-            upload_python_package : str = None,
+            upload_python_package : Optional[List[os.PathLike]] = None,
     ):
         self.loop = ConcurrentLearningLoop(
             name+'-loop',
@@ -293,7 +294,7 @@ def _loop (
         name : str,
         block_op : OPTemplate,
         step_config : dict = normalize_step_dict({}),
-        upload_python_package : str = None,
+        upload_python_package : Optional[List[os.PathLike]] = None,
 ):    
     step_config = deepcopy(step_config)
     step_template_config = step_config.pop('template_config')
@@ -413,7 +414,7 @@ def _dpgen(
         loop_op,
         loop_key,
         step_config : dict = normalize_step_dict({}),
-        upload_python_package : str = None
+        upload_python_package : Optional[List[os.PathLike]] = None
 ):    
     step_config = deepcopy(step_config)
     step_template_config = step_config.pop('template_config')

--- a/dpgen2/fp/vasp.py
+++ b/dpgen2/fp/vasp.py
@@ -14,9 +14,9 @@ class VaspInputs():
     def __init__(
             self,
             kspacing : Union[float, List[float]],
+            incar_template_name : str,
+            potcar_names : Dict[str, str],
             kgamma : bool = True,
-            incar_template_name : Optional[str]= None,
-            potcar_names : Optional[Dict[str, str]] = None,
     ):
         """
         Parameters
@@ -38,10 +38,7 @@ class VaspInputs():
         """
         self.kspacing = kspacing
         self.kgamma = kgamma
-        # TODO: not acctually optional
-        assert incar_template_name is not None
         self.incar_from_file(incar_template_name)
-        assert potcar_names is not None
         self.potcars_from_file(potcar_names)
 
     @property

--- a/dpgen2/fp/vasp.py
+++ b/dpgen2/fp/vasp.py
@@ -2,6 +2,7 @@ import numpy as np
 import dpdata
 from pathlib import Path
 from typing import (
+    Optional,
     Tuple, 
     List, 
     Set, 
@@ -14,8 +15,8 @@ class VaspInputs():
             self,
             kspacing : Union[float, List[float]],
             kgamma : bool = True,
-            incar_template_name : str = None,
-            potcar_names : Dict[str, str] = None,
+            incar_template_name : Optional[str]= None,
+            potcar_names : Optional[Dict[str, str]] = None,
     ):
         """
         Parameters
@@ -37,7 +38,10 @@ class VaspInputs():
         """
         self.kspacing = kspacing
         self.kgamma = kgamma
+        # TODO: not acctually optional
+        assert incar_template_name is not None
         self.incar_from_file(incar_template_name)
+        assert potcar_names is not None
         self.potcars_from_file(potcar_names)
 
     @property
@@ -73,7 +77,7 @@ class VaspInputs():
 
     def make_kpoints(
             self,
-            box : np.array,
+            box : np.ndarray,
     ) -> str:
         return make_kspacing_kpoints(box, self.kspacing, self.kgamma)
 

--- a/dpgen2/fp/vasp.py
+++ b/dpgen2/fp/vasp.py
@@ -25,8 +25,6 @@ class VaspInputs():
                 The kspacing. If it is a number, then three directions use the same
                 ksapcing, otherwise it is a list of three numbers, specifying the
                 kspacing used in the x, y and z dimension.
-        kgamma : bool
-                K-mesh includes the gamma point
         incar_template_name: str
                 A template INCAR file. 
         potcar_names : Dict[str,str]
@@ -35,6 +33,8 @@ class VaspInputs():
                    "H" : "/path/to/POTCAR_H",
                    "O" : "/path/to/POTCAR_O",
                 }
+        kgamma : bool
+                K-mesh includes the gamma point
         """
         self.kspacing = kspacing
         self.kgamma = kgamma

--- a/dpgen2/op/md_settings.py
+++ b/dpgen2/op/md_settings.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Optional
 
 class MDSettings():
     def __init__(
@@ -8,18 +8,18 @@ class MDSettings():
             dt : float,
             nsteps : int,
             trj_freq : int,
-            temps : List[float] = None,
-            press : List[float] = None,
+            temps : Optional[List[float]] = None,
+            press : Optional[List[float]] = None,
             tau_t : float = 0.1,
             tau_p : float = 0.5,
-            pka_e : float = None,
-            neidelay : int = None,
+            pka_e : Optional[float] = None,
+            neidelay : Optional[int] = None,
             no_pbc : bool = False,
             use_clusters : bool = False,
-            relative_epsilon : float = None,
-            relative_v_epsilon : float = None,
-            ele_temp_f : float = None,
-            ele_temp_a : float = None,
+            relative_epsilon : Optional[float] = None,
+            relative_v_epsilon : Optional[float] = None,
+            ele_temp_f : Optional[float] = None,
+            ele_temp_a : Optional[float] = None,
     )->None:
         self.ens = ens
         self.temps = temps

--- a/dpgen2/op/prep_vasp.py
+++ b/dpgen2/op/prep_vasp.py
@@ -109,7 +109,7 @@ class PrepVasp(OP):
             idx,
             vasp_inputs : VaspInputs,
             conf_frame : dpdata.System,
-    ) -> str:
+    ) -> Tuple[str, Path]:
         task_name = vasp_task_pattern % idx
         task_path = Path(task_name)
         with set_directory(task_path):

--- a/dpgen2/superop/block.py
+++ b/dpgen2/superop/block.py
@@ -27,7 +27,7 @@ from dpgen2.utils.step_config import normalize as normalize_step_dict
 from dpgen2.utils.step_config import init_executor
 
 import os
-from typing import Set, List
+from typing import Any, Dict, Optional, Set, List
 from pathlib import Path
 from copy import deepcopy
 
@@ -42,7 +42,7 @@ class ConcurrentLearningBlock(Steps):
             collect_data_op : OP,
             select_confs_config : dict = normalize_step_dict({}),
             collect_data_config : dict = normalize_step_dict({}),
-            upload_python_package : str = None,
+            upload_python_package : Optional[List[os.PathLike]] = None,
     ):
         self._input_parameters={
             "block_id" : InputParameter(),
@@ -131,7 +131,7 @@ class ConcurrentLearningBlock(Steps):
 
 def _block_cl(
         block_steps : Steps,
-        step_keys : List[str],
+        step_keys : Dict[str, Any],
         name : str,
         prep_run_dp_train_op : OPTemplate,
         prep_run_lmp_op : OPTemplate,
@@ -140,7 +140,7 @@ def _block_cl(
         collect_data_op : OP,
         select_confs_config : dict = normalize_step_dict({}),
         collect_data_config : dict = normalize_step_dict({}),
-        upload_python_package : str = None,
+        upload_python_package : Optional[List[os.PathLike]] = None,
 ):
     select_confs_config = deepcopy(select_confs_config)
     collect_data_config = deepcopy(collect_data_config)

--- a/dpgen2/superop/prep_run_dp_train.py
+++ b/dpgen2/superop/prep_run_dp_train.py
@@ -29,7 +29,7 @@ from dpgen2.utils.step_config import normalize as normalize_step_dict
 from dpgen2.utils.step_config import init_executor
 
 import os
-from typing import Set, List
+from typing import Optional, Set, List
 from pathlib import Path
 from copy import deepcopy
 
@@ -41,7 +41,7 @@ class PrepRunDPTrain(Steps):
             run_train_op : OP,
             prep_config : dict = normalize_step_dict({}),
             run_config : dict = normalize_step_dict({}),
-            upload_python_package : str = None,
+            upload_python_package : Optional[List[os.PathLike]] = None,
     ):
         self._input_parameters = {
             "block_id" : InputParameter(type=str, value=""),
@@ -122,7 +122,7 @@ def _prep_run_dp_train(
         run_train_op : OP,
         prep_config : dict = normalize_step_dict({}),
         run_config : dict = normalize_step_dict({}),
-        upload_python_package : str = None,
+        upload_python_package : Optional[List[os.PathLike]] = None,
 ):
     prep_config = deepcopy(prep_config)
     run_config = deepcopy(run_config)

--- a/dpgen2/superop/prep_run_fp.py
+++ b/dpgen2/superop/prep_run_fp.py
@@ -29,7 +29,7 @@ from dpgen2.utils.step_config import normalize as normalize_step_dict
 from dpgen2.utils.step_config import init_executor
 
 import os
-from typing import Set, List
+from typing import Optional, Set, List
 from pathlib import Path
 from copy import deepcopy
 
@@ -41,7 +41,7 @@ class PrepRunFp(Steps):
             run_op : OP,
             prep_config : dict = normalize_step_dict({}),
             run_config : dict = normalize_step_dict({}),
-            upload_python_package : str = None,
+            upload_python_package : Optional[List[os.PathLike]] = None,
     ):
         self._input_parameters = {
             "block_id" : InputParameter(type=str, value=""),
@@ -121,7 +121,7 @@ def _prep_run_fp(
         run_op : OP,
         prep_config : dict = normalize_step_dict({}),
         run_config : dict = normalize_step_dict({}),
-        upload_python_package : str = None,
+        upload_python_package : Optional[List[os.PathLike]] = None,
 ):
     prep_config = deepcopy(prep_config)
     run_config = deepcopy(run_config)

--- a/dpgen2/superop/prep_run_lmp.py
+++ b/dpgen2/superop/prep_run_lmp.py
@@ -29,7 +29,7 @@ from dpgen2.utils.step_config import normalize as normalize_step_dict
 from dpgen2.utils.step_config import init_executor
 
 import os
-from typing import Set, List
+from typing import Optional, Set, List
 from pathlib import Path
 from copy import deepcopy
 
@@ -41,7 +41,7 @@ class PrepRunLmp(Steps):
             run_op : OP,
             prep_config : dict = normalize_step_dict({}),
             run_config : dict = normalize_step_dict({}),
-            upload_python_package : str = None,
+            upload_python_package : Optional[List[os.PathLike]] = None,
     ):
         self._input_parameters = {
             "block_id" : InputParameter(type=str, value=""),
@@ -122,7 +122,7 @@ def _prep_run_lmp(
         run_op : OP,
         prep_config : dict = normalize_step_dict({}),
         run_config : dict = normalize_step_dict({}),
-        upload_python_package : str = None,
+        upload_python_package : Optional[List[os.PathLike]] = None,
 ):
     prep_config = deepcopy(prep_config)
     run_config = deepcopy(run_config)

--- a/dpgen2/utils/alloy_conf.py
+++ b/dpgen2/utils/alloy_conf.py
@@ -4,7 +4,7 @@ import tempfile
 import numpy as np
 from pathlib import Path
 from typing import (
-    Union, List, Tuple
+    Optional, Union, List, Tuple
 )
 from dargs import (
     Argument,
@@ -31,15 +31,16 @@ class AlloyConf():
             self,
             lattice : Union[dpdata.System, Tuple[str,float]],
             type_map : List[str],
-            replicate : Union[List[int], Tuple[int], int] = None,
+            replicate : Union[List[int], Tuple[int], int, None] = None,
     )->None:
         # init sys
-        if type(lattice) != dpdata.System: 
+        if not isinstance(lattice, dpdata.System): 
             sys = generate_unit_cell(lattice[0], lattice[1])
         else:
             sys = lattice
+        assert not isinstance(sys, tuple)
         # replicate
-        if type(replicate) == int:
+        if isinstance(replicate, int):
             replicate = [replicate] * 3
         if replicate is not None:
             sys = sys.replicate(replicate)            
@@ -136,7 +137,7 @@ class AlloyConf():
             concentration: Union[List[List[float]], List[float], None] = None,
             cell_pert_frac: float = 0.0,
             atom_pert_dist: float = 0.0,
-    ) -> str:        
+    ) -> dpdata.System:        
         if concentration is None:
             cc = [1./float(self.ntypes) for ii in range(self.ntypes)]
         elif type(concentration) is list and type(concentration[0]) is list:
@@ -149,7 +150,7 @@ class AlloyConf():
         ret_sys = self.sys.perturb(1, cell_pert_frac, atom_pert_dist)[0]
         ret_sys.data['atom_types'] = np.array(random.choices(
             self.type_population, 
-            weights=cc,
+            weights=cc, # type: ignore
             k=self.natoms,
         ), dtype=int)
         ret_sys.data['atom_numbs'] = list(np.bincount(
@@ -209,7 +210,7 @@ def generate_alloy_conf_file_content(
         lattice : Union[dpdata.System, Tuple[str,float]],
         type_map : List[str],
         numb_confs,
-        replicate : Union[List[int], Tuple[int], int] = None,
+        replicate : Union[List[int], Tuple[int], int, None] = None,
         concentration: Union[List[List[float]], List[float], None] = None,
         cell_pert_frac: float = 0.0,
         atom_pert_dist: float = 0.0,

--- a/dpgen2/utils/dflow_query.py
+++ b/dpgen2/utils/dflow_query.py
@@ -6,7 +6,7 @@ from typing import (
 
 def get_subkey(
         key : str, 
-        idx : Optional[int] = -1, 
+        idx : int = -1, 
 ):
     return key.split('--')[idx]
 

--- a/dpgen2/utils/run_command.py
+++ b/dpgen2/utils/run_command.py
@@ -2,7 +2,7 @@ import sys, subprocess
 
 def run_command(
         cmd,
-        shell = None,
+        shell: bool = False,
 ):
     pp = subprocess.Popen(
         cmd, 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 	     'dpdata',
 	     'pydflow>=1.5.10',
 	     'dargs>=0.3.1',
+	     'scipy',
 ]
 requires-python = ">=3.7"
 readme = "README.md"
@@ -52,3 +53,8 @@ dpgen2 = ['*.json']
 
 [tool.setuptools_scm]
 write_to = "dpgen2/_version.py"
+
+[tool.pyright]
+include = [
+     "dpgen2",
+]

--- a/tests/fp/test_vasp.py
+++ b/tests/fp/test_vasp.py
@@ -35,7 +35,7 @@ class TestVASPInputs(unittest.TestCase):
     def test_vasp_input_incar_potcar(self):
         iincar = 'template.incar'
         ipotcar = {'H' : 'POTCAR_H', 'O' : 'POTCAR_O'}
-        vi = VaspInputs(0.16, True, iincar, ipotcar)
+        vi = VaspInputs(0.16, iincar, ipotcar, True)
         self.assertEqual(vi.incar_template, 'foo')
         self.assertEqual(vi.potcars['O'], 'bar O\n')
         self.assertEqual(vi.potcars['H'], 'bar H\n')
@@ -67,7 +67,7 @@ Cartesian
         Path('POSCAR').write_text(poscar)
         iincar = 'template.incar'
         ipotcar = {'H' : 'POTCAR_H', 'O' : 'POTCAR_O'}
-        vi = VaspInputs(0.1, True, iincar, ipotcar)
+        vi = VaspInputs(0.1, iincar, ipotcar, True)
         ss = dpdata.System('POSCAR')
         kps = vi.make_kpoints(ss['cells'][0])
         self.assertEqual(ref, kps)
@@ -98,7 +98,7 @@ Cartesian
         Path('POSCAR').write_text(poscar)
         iincar = 'template.incar'
         ipotcar = {'H' : 'POTCAR_H', 'O' : 'POTCAR_O'}
-        vi = VaspInputs(0.1, False, iincar, ipotcar)
+        vi = VaspInputs(0.1, iincar, ipotcar, False)
         ss = dpdata.System('POSCAR')
         kps = vi.make_kpoints(ss['cells'][0])
         self.assertEqual(ref, kps)

--- a/tests/op/test_prep_vasp.py
+++ b/tests/op/test_prep_vasp.py
@@ -73,7 +73,7 @@ Gamma
 """)
         iincar = 'template.incar'
         ipotcar = {'H' : 'POTCAR_H', 'O' : 'POTCAR_O'}
-        vi = VaspInputs(0.1, True, iincar, ipotcar)
+        vi = VaspInputs(0.1, iincar, ipotcar, True)
         op = PrepVasp()
         opout = op.execute(OPIO({
             'config': {'inputs' : vi},

--- a/tests/test_block_cl.py
+++ b/tests/test_block_cl.py
@@ -152,9 +152,10 @@ class TestBlockCL(unittest.TestCase):
         self.potcar = Path('potcar')
         self.potcar.write_text('bar')
         self.vasp_inputs = VaspInputs(
-            0.16, True,
+            0.16,
             self.incar,
             {'foo': self.potcar},
+            True,
         )
 
     def setUp(self):

--- a/tests/test_dpgen_loop.py
+++ b/tests/test_dpgen_loop.py
@@ -188,9 +188,10 @@ class TestLoop(unittest.TestCase):
         self.potcar = Path('potcar')
         self.potcar.write_text('bar')
         self.vasp_inputs = VaspInputs(
-            0.16, True,
+            0.16,
             self.incar,
             {'foo': 'potcar'},
+            True,
         )
 
         self.scheduler = ExplorationScheduler()        
@@ -466,9 +467,10 @@ class TestLoopRestart(unittest.TestCase):
         self.potcar = Path('potcar')
         self.potcar.write_text('bar')
         self.vasp_inputs = VaspInputs(
-            0.16, True,
+            0.16,
             self.incar,
             {'foo': self.potcar},
+            True,
         )
 
         self.scheduler_0 = ExplorationScheduler()        

--- a/tests/test_prep_run_vasp.py
+++ b/tests/test_prep_run_vasp.py
@@ -109,9 +109,9 @@ class TestPrepVaspTaskGroup(unittest.TestCase):
         op = MockedPrepVasp()
         vasp_inputs = VaspInputs(
                 0.16,
-                True,
                 self.incar,
                 {'foo': self.potcar}
+                True,
             )
         out = op.execute( OPIO({
             'confs' : self.confs,
@@ -226,9 +226,9 @@ class TestPrepRunVasp(unittest.TestCase):
         )
         vasp_inputs = VaspInputs(
             0.16,
-            True,
             self.incar,
-            {'foo': self.potcar}
+            {'foo': self.potcar},
+            True,
         )
         prep_run_step = Step(
             'prep-run-step', 

--- a/tests/test_prep_run_vasp.py
+++ b/tests/test_prep_run_vasp.py
@@ -110,7 +110,7 @@ class TestPrepVaspTaskGroup(unittest.TestCase):
         vasp_inputs = VaspInputs(
                 0.16,
                 self.incar,
-                {'foo': self.potcar}
+                {'foo': self.potcar},
                 True,
             )
         out = op.execute( OPIO({


### PR DESCRIPTION
This commit uses microsoft/pyright as a type checker. Several errors have been fixed.
Sometimes the type of a variable is too "dynamic". It will be helpful to use `assert` to narrow the types. Finally, one can add `# type: ignore` to skip the type checking of a line.
