### PR TITLE
fix codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: | 
         pip install -e .
-        pip install mock coverage codecov 
+        pip install mock coverage 
     - name: Test
       run: SKIP_UT_WITH_DFLOW=0 DFLOW_DEBUG=1 coverage run --source=./dpgen2 -m unittest && coverage report
-    - run: codecov
+    - uses: codecov/codecov-action@v3


### PR DESCRIPTION
Codecov python package is deprecated does not work any more. This patch migrates it to another version.