### PR TITLE
Replace the scheduler in the old workflow by the new one

### DIFF
--- a/dpgen2/entrypoint/main.py
+++ b/dpgen2/entrypoint/main.py
@@ -91,7 +91,10 @@ def main_parser() -> argparse.ArgumentParser:
         "-l", "--list", action='store_true', help="list the Steps of the existing workflow."
     )
     parser_resubmit.add_argument(
-        "--reuse", type=str, nargs='+', default=None, help="specify which Steps to reuse."
+        "-u", "--reuse", type=str, nargs='+', default=None, help="specify which Steps to reuse."
+    )
+    parser_resubmit.add_argument(
+        "-s", "--replace-scheduler", action='store_true', help="replace the scheduler defined in the old workflow by that defined in the input script."
     )
     parser_resubmit.add_argument(
         "-o", "--old-compatible", action='store_true', help="compatible with old-style input script used in dpgen2 < 0.0.6."
@@ -241,6 +244,7 @@ def main():
             list_steps=args.list, 
             reuse=args.reuse,
             old_style=args.old_compatible,
+            replace_scheduler=args.replace_scheduler,
         )
     elif args.command == "status":
         with open(args.CONFIG) as fp:

--- a/dpgen2/entrypoint/main.py
+++ b/dpgen2/entrypoint/main.py
@@ -94,7 +94,7 @@ def main_parser() -> argparse.ArgumentParser:
         "-u", "--reuse", type=str, nargs='+', default=None, help="specify which Steps to reuse."
     )
     parser_resubmit.add_argument(
-        "-s", "--replace-scheduler", action='store_true', help="replace the scheduler defined in the old workflow by that defined in the input script."
+        "-k", "--keep-schedule", action='store_true', help="if set then keep schedule of the old workflow. otherwise use the schedule defined in the input file"
     )
     parser_resubmit.add_argument(
         "-o", "--old-compatible", action='store_true', help="compatible with old-style input script used in dpgen2 < 0.0.6."
@@ -244,7 +244,7 @@ def main():
             list_steps=args.list, 
             reuse=args.reuse,
             old_style=args.old_compatible,
-            replace_scheduler=args.replace_scheduler,
+            replace_scheduler=(not args.keep_schedule),
         )
     elif args.command == "status":
         with open(args.CONFIG) as fp:

--- a/dpgen2/entrypoint/status.py
+++ b/dpgen2/entrypoint/status.py
@@ -4,6 +4,7 @@ from dflow import (
 )
 from dpgen2.utils.dflow_query import (
     get_last_scheduler,
+    get_all_schedulers,
 )
 from typing import (
     Optional, Dict, Union, List,

--- a/dpgen2/entrypoint/submit.py
+++ b/dpgen2/entrypoint/submit.py
@@ -456,9 +456,9 @@ def copy_scheduler_plans(
 
 def submit_concurrent_learning(
         wf_config,
-        reuse_step = None,
-        old_style = False,
-        replace_scheduler = False,
+        reuse_step : Optional[List[Step]] = None,
+        old_style : bool = False,
+        replace_scheduler: bool = False,
 ):
     # normalize args
     wf_config = normalize_args(wf_config)
@@ -469,7 +469,7 @@ def submit_concurrent_learning(
     
     dpgen_step = workflow_concurrent_learning(wf_config, old_style=old_style)
     
-    if replace_scheduler:
+    if reuse_step is not None and replace_scheduler:
         scheduler_new = copy.deepcopy(dpgen_step.inputs.parameters['exploration_scheduler'].value)
         idx_old = get_scheduler_ids(reuse_step)[-1]
         scheduler_old = reuse_step[idx_old].inputs.parameters['exploration_scheduler'].value

--- a/dpgen2/exploration/report/report_trust_levels.py
+++ b/dpgen2/exploration/report/report_trust_levels.py
@@ -9,12 +9,6 @@ from typing import (
 from dflow.python import FatalError
 
 class ExplorationReportTrustLevels(ExplorationReport):
-    # class attrs
-    spaces = [8, 8, 8, 10, 10, 10]
-    fmt_str = ' '.join([f'%{ii}s' for ii in spaces])
-    fmt_flt = '%.4f'
-    header_str = '#' + fmt_str % ('stage', 'id_stg.', 'iter.', 'accu.', 'cand.', 'fail.')
-
     def __init__(
             self,
             trust_level,
@@ -25,6 +19,21 @@ class ExplorationReportTrustLevels(ExplorationReport):
         self.clear()
         self.v_level = ( (self.trust_level.level_v_lo is not None) and \
                          (self.trust_level.level_v_hi is not None) )
+
+        print_tuple = ('stage', 'id_stg.', 'iter.',
+                       'accu.', 'cand.', 'fail.',
+                       'lvl_f_lo', 'lvl_f_hi',
+        )
+        spaces = [8, 8, 8, 10, 10, 10, 10, 10]
+        if self.v_level:
+            print_tuple += ('v_lo', 'v_hi',)
+            spaces += [10, 10]
+        print_tuple += ('cvged',)
+        spaces += [8]
+        self.fmt_str = ' '.join([f'%{ii}s' for ii in spaces])
+        self.fmt_flt = '%.4f'
+        self.header_str = '#' + self.fmt_str % print_tuple
+
 
     def clear(
             self,
@@ -186,7 +195,7 @@ class ExplorationReportTrustLevels(ExplorationReport):
         
     def print_header(self) -> str:
         r"""Print the header of report"""
-        return ExplorationReportTrustLevels.header_str
+        return self.header_str
 
     def print(
             self, 
@@ -195,12 +204,23 @@ class ExplorationReportTrustLevels(ExplorationReport):
             iter_idx : int,
     ) -> str:
         r"""Print the report"""
-        fmt_str = ExplorationReportTrustLevels.fmt_str
-        fmt_flt = ExplorationReportTrustLevels.fmt_flt
-        ret = ' ' + fmt_str % (
-            str(stage_idx), str(idx_in_stage), str(iter_idx),
-            fmt_flt%(self.accurate_ratio()),
-            fmt_flt%(self.candidate_ratio()),
-            fmt_flt%(self.failed_ratio()),
+        fmt_str = self.fmt_str
+        fmt_flt = self.fmt_flt
+        print_tuple = (
+                str(stage_idx), str(idx_in_stage), str(iter_idx),
+                fmt_flt%(self.accurate_ratio()),
+                fmt_flt%(self.candidate_ratio()),
+                fmt_flt%(self.failed_ratio()),
+                fmt_flt%(self.trust_level.level_f_lo),
+                fmt_flt%(self.trust_level.level_f_hi),
         )
+        if self.v_level:
+            print_tuple += (
+                fmt_flt%(self.trust_level.level_v_lo),
+                fmt_flt%(self.trust_level.level_v_hi),
+            )
+        print_tuple += (
+            str(self.converged()),
+        )
+        ret = ' ' + fmt_str % print_tuple
         return ret

--- a/dpgen2/exploration/scheduler/convergence_check_stage_scheduler.py
+++ b/dpgen2/exploration/scheduler/convergence_check_stage_scheduler.py
@@ -36,6 +36,9 @@ class ConvergenceCheckStageScheduler(StageScheduler):
     def complete(self):
         return self.complete_
 
+    def force_complete(self):
+        self.complete_ = True
+
     def next_iteration(self):
         return self.nxt_iter
 
@@ -50,6 +53,10 @@ class ConvergenceCheckStageScheduler(StageScheduler):
             report : Optional[ExplorationReport] = None,
             trajs : Optional[List[Path]] = None,
     ) -> Tuple[bool, Optional[ExplorationTaskGroup], Optional[ConfSelector]] :
+        if self.complete():
+            raise FatalError(
+                'Cannot plan because the stage has completed.'
+            )
         if report is None:
             stg_complete = False
             self.conv = stg_complete

--- a/dpgen2/exploration/scheduler/convergence_check_stage_scheduler.py
+++ b/dpgen2/exploration/scheduler/convergence_check_stage_scheduler.py
@@ -30,8 +30,14 @@ class ConvergenceCheckStageScheduler(StageScheduler):
         self.complete_ = False
         self.reports = []
 
+    def get_reports(self):
+        return self.reports
+
     def complete(self):
         return self.complete_
+
+    def next_iteration(self):
+        return self.nxt_iter
 
     def converged(self):
         return self.conv

--- a/dpgen2/exploration/scheduler/scheduler.py
+++ b/dpgen2/exploration/scheduler/scheduler.py
@@ -188,6 +188,32 @@ class ExplorationScheduler():
         else:
             return None
 
+
+    def print_last_iteration(self, print_header=False):
+        stages = self.stage_schedulers
+        
+        stage_idx, idx_in_stage, iter_idx = self.get_stage_of_iterations()
+
+        if np.size(iter_idx) == 0:
+            return "No finished iteration found\n"
+
+        iidx = np.size(iter_idx)-1
+        
+        ret = []
+        if print_header:
+            ret.append(
+                stages[stage_idx[iidx]].reports[idx_in_stage[iidx]].print_header())
+        ret.append(
+            stages[stage_idx[iidx]].reports[idx_in_stage[iidx]]\
+            .print(stage_idx[iidx], idx_in_stage[iidx], iidx)
+        )
+
+        if self.complete():
+            ret.append(f'# All stages converged')
+        return '\n'.join(ret + [''])
+        
+
+
     def print_convergence(self):
         ret = []
         stages = self.stage_schedulers

--- a/dpgen2/exploration/scheduler/scheduler.py
+++ b/dpgen2/exploration/scheduler/scheduler.py
@@ -82,6 +82,20 @@ class ExplorationScheduler():
         """
         return self.complete_
 
+    def force_stage_complete(self):
+        """
+        Force complete the current stage 
+
+        """
+        self.stage_schedulers[self.cur_stage].force_complete()
+        self.cur_stage += 1
+        if self.cur_stage < len(self.stage_schedulers):
+            # goes to next stage
+            self.plan_next_iteration()
+        else:
+            # all stages complete
+            self.complete_ = True
+
     def plan_next_iteration(
             self,
             report : Optional[ExplorationReport] = None,
@@ -116,7 +130,7 @@ class ExplorationScheduler():
                 )
         except FatalError as e:
             raise FatalError(f'stage {self.cur_stage}: ' + str(e))
-        
+
         if stg_complete:
             self.cur_stage += 1
             if self.cur_stage < len(self.stage_schedulers):

--- a/dpgen2/exploration/scheduler/scheduler.py
+++ b/dpgen2/exploration/scheduler/scheduler.py
@@ -28,7 +28,6 @@ class ExplorationScheduler():
     ):
         self.stage_schedulers = []
         self.cur_stage = 0
-        self.iteration = -1
         self.complete_ = False
         
     def add_stage_scheduler(
@@ -66,7 +65,15 @@ class ExplorationScheduler():
         Iteration index increase when `self.plan_next_iteration` returns valid `lmp_task_grp` and `conf_selector` for the next iteration.
 
         """
-        return self.iteration
+        tot_iter = -1
+        for idx,ii in enumerate(self.stage_schedulers):
+            if ii.complete():
+                # the last plan is not used because the stage
+                # is found converged
+                tot_iter += ii.next_iteration() - 1
+            else:
+                tot_iter += ii.next_iteration()
+        return tot_iter
 
     def complete(self):
         """
@@ -120,7 +127,6 @@ class ExplorationScheduler():
                 self.complete_ = True
                 return True, None, None,
         else :
-            self.iteration += 1
             return stg_complete, lmp_task_grp, conf_selector
 
 

--- a/dpgen2/exploration/scheduler/stage_scheduler.py
+++ b/dpgen2/exploration/scheduler/stage_scheduler.py
@@ -17,7 +17,7 @@ class StageScheduler(ABC):
     """
 
     @abstractmethod
-    def converged(self):
+    def converged(self)->bool:
         """
         Tell if the stage is converged
 
@@ -25,6 +25,42 @@ class StageScheduler(ABC):
         -------
         converged  bool
                    the convergence
+        """
+        pass
+
+    @abstractmethod
+    def converged(self)->bool:
+        """
+        Tell if the stage is complete
+
+        Returns
+        -------
+        converged  bool
+                   if the stage is complete
+        """
+        pass
+
+    @abstractmethod
+    def next_iteration(self)->int:
+        """
+        Return the index of the next iteration
+
+        Returns
+        -------
+        index  int
+                   the index of the next iteration
+        """
+        pass
+
+    @abstractmethod
+    def get_reports(self)->List[ExplorationReport]:
+        """
+        Return all exploration reports
+
+        Returns
+        -------
+        reports  List[ExplorationReport]
+                   the reports
         """
         pass
 

--- a/dpgen2/exploration/scheduler/stage_scheduler.py
+++ b/dpgen2/exploration/scheduler/stage_scheduler.py
@@ -29,7 +29,7 @@ class StageScheduler(ABC):
         pass
 
     @abstractmethod
-    def converged(self)->bool:
+    def complete(self)->bool:
         """
         Tell if the stage is complete
 
@@ -37,6 +37,14 @@ class StageScheduler(ABC):
         -------
         converged  bool
                    if the stage is complete
+        """
+        pass
+
+    @abstractmethod
+    def force_complete(self):
+        """
+        For complete the stage
+
         """
         pass
 

--- a/dpgen2/utils/dflow_query.py
+++ b/dpgen2/utils/dflow_query.py
@@ -51,6 +51,22 @@ def get_last_scheduler(
         step = wf.query_step(key=skey)[0]
         return step.outputs.parameters['exploration_scheduler'].value
 
+def get_all_schedulers(
+        wf : Any,
+        keys : List[str],
+):
+    """
+    get the output Scheduler of the all the iterations
+    """
+    scheduler_keys = sorted(matched_step_key(keys, ['scheduler']))
+    if len(scheduler_keys) == 0:
+        return None
+    else:
+        all_schedulers = [
+            wf.query_step(key=skey)[0].outputs.parameters['exploration_scheduler'].value
+            for skey in scheduler_keys
+        ]
+    return all_schedulers
         
 def get_last_iteration(
         keys : List[str], 

--- a/dpgen2/utils/dflow_query.py
+++ b/dpgen2/utils/dflow_query.py
@@ -28,7 +28,8 @@ def matched_step_key(
     for kk in all_keys:
         for jj in step_keys:
             if re.match(f'iter-[0-9]*--{jj}-[0-9]*', kk) or\
-               re.match(f'iter-[0-9]*--{jj}', kk):
+               re.match(f'iter-[0-9]*--{jj}', kk) or\
+               re.match(f'init--{jj}', kk):
                 ret.append(kk)
                 continue
     return ret

--- a/tests/entrypoint/context.py
+++ b/tests/entrypoint/context.py
@@ -1,3 +1,4 @@
 import sys,os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import dpgen2

--- a/tests/entrypoint/test_submit.py
+++ b/tests/entrypoint/test_submit.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from dpgen2.entrypoint.submit import (
     expand_idx,
     print_list_steps,
+    update_reuse_step_scheduler,
 )
 
 ifc0 = """Al1 
@@ -47,6 +48,20 @@ cartesian
 ofc2 = '\n1 atoms\n2 atom types\n   0.0000000000    4.0000000000 xlo xhi\n   0.0000000000    4.0000000000 ylo yhi\n   0.0000000000    4.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n'
 
 
+class MockedScheduler():
+    def __init__(self, value=0):
+        self.value = value
+
+class MockedStep():
+    def __init__(self, scheduler=None):
+        self.scheduler = scheduler
+        self.key = f"iter-{self.scheduler.value}--scheduler"
+
+    def modify_output_artifact(self, key, scheduler):
+        assert key == "exploration_scheduler"
+        self.scheduler = scheduler
+
+
 class TestSubmit(unittest.TestCase):
     def test_expand_idx(self):
         ilist = ['1', '3-5', '10-20:2']
@@ -60,3 +75,21 @@ class TestSubmit(unittest.TestCase):
         ostr = print_list_steps(ilist)
         expected_ostr = '       0    foo\n       1    bar'
         self.assertEqual(ostr, expected_ostr)
+
+
+    def test_update_reuse_step_scheduler(self):
+        reuse_steps = [
+            MockedStep(MockedScheduler(0)),
+            MockedStep(MockedScheduler(1)),
+            MockedStep(MockedScheduler(2)),
+            MockedStep(MockedScheduler(3)),
+        ]
+        reuse_steps = update_reuse_step_scheduler(
+            reuse_steps, 
+            MockedScheduler(4),
+        )
+        self.assertEqual(len(reuse_steps), 4)
+        self.assertEqual(reuse_steps[0].scheduler.value, 0)
+        self.assertEqual(reuse_steps[1].scheduler.value, 1)
+        self.assertEqual(reuse_steps[2].scheduler.value, 2)
+        self.assertEqual(reuse_steps[3].scheduler.value, 4)

--- a/tests/entrypoint/test_submit.py
+++ b/tests/entrypoint/test_submit.py
@@ -9,7 +9,24 @@ from dpgen2.entrypoint.submit import (
     expand_idx,
     print_list_steps,
     update_reuse_step_scheduler,
+    copy_scheduler_plans,
 )
+from dpgen2.exploration.scheduler import (
+    ConvergenceCheckStageScheduler,
+    ExplorationScheduler,
+)
+from dpgen2.exploration.report import ExplorationReport, ExplorationReportTrustLevels
+from dpgen2.exploration.task import ExplorationTaskGroup, ExplorationStage
+from dpgen2.exploration.selector import TrustLevel, ConfSelectorFrames
+from dpgen2.exploration.render import TrajRenderLammps
+from mocked_ops import (
+    MockedExplorationReport,
+    MockedExplorationTaskGroup,
+    MockedExplorationTaskGroup1,
+    MockedStage,
+    MockedStage1,
+)
+
 
 ifc0 = """Al1 
 1.0
@@ -57,7 +74,7 @@ class MockedStep():
         self.scheduler = scheduler
         self.key = f"iter-{self.scheduler.value}--scheduler"
 
-    def modify_output_artifact(self, key, scheduler):
+    def modify_output_parameter(self, key, scheduler):
         assert key == "exploration_scheduler"
         self.scheduler = scheduler
 
@@ -84,6 +101,7 @@ class TestSubmit(unittest.TestCase):
             MockedStep(MockedScheduler(2)),
             MockedStep(MockedScheduler(3)),
         ]
+
         reuse_steps = update_reuse_step_scheduler(
             reuse_steps, 
             MockedScheduler(4),
@@ -93,3 +111,196 @@ class TestSubmit(unittest.TestCase):
         self.assertEqual(reuse_steps[1].scheduler.value, 1)
         self.assertEqual(reuse_steps[2].scheduler.value, 2)
         self.assertEqual(reuse_steps[3].scheduler.value, 4)
+
+
+    def test_copy_scheduler(self):
+        scheduler = ExplorationScheduler()
+        scheduler_new = ExplorationScheduler()
+        trust_level = TrustLevel(0.1, 0.3)
+        report = ExplorationReportTrustLevels(trust_level, 0.9)
+        traj_render = TrajRenderLammps()        
+        selector = ConfSelectorFrames(traj_render, report)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage(),
+            selector,
+            max_numb_iter = 2,
+        )
+        scheduler.add_stage_scheduler(stage_scheduler)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage(),
+            selector,
+            max_numb_iter = 2,
+        )
+        scheduler_new.add_stage_scheduler(stage_scheduler)
+
+        trust_level = TrustLevel(0.2, 0.4)
+        report = ExplorationReportTrustLevels(trust_level, 0.9)
+        traj_render = TrajRenderLammps()        
+        selector = ConfSelectorFrames(traj_render, report)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage1(),
+            selector,
+            max_numb_iter = 3,
+        )
+        scheduler.add_stage_scheduler(stage_scheduler)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage1(),
+            selector,
+            max_numb_iter = 3,
+        )
+        scheduler_new.add_stage_scheduler(stage_scheduler)
+
+        foo_report = MockedExplorationReport()
+        foo_report.accurate = 0.5
+        foo_report.failed = 0.5          
+        bar_report = MockedExplorationReport()
+        bar_report.accurate = 1.0
+        bar_report.failed = 0.0        
+        
+        conv, ltg, sel = scheduler.plan_next_iteration()
+        self.assertEqual(conv, False)
+        self.assertTrue(isinstance(ltg, MockedExplorationTaskGroup))
+        self.assertTrue(isinstance(sel, ConfSelectorFrames))
+        self.assertEqual(sel.report.trust_level.level_f_lo, 0.1)
+        self.assertEqual(sel.report.trust_level.level_f_hi, 0.3)
+        self.assertTrue(sel.report.trust_level.level_v_lo is None)
+        self.assertTrue(sel.report.trust_level.level_v_hi is None)
+        self.assertEqual(scheduler.get_stage(), 0)
+        self.assertEqual(scheduler.get_iteration(), 0)
+        self.assertEqual(len(scheduler.stage_schedulers), 2)
+        self.assertFalse(scheduler.stage_schedulers[0].converged())
+        conv, ltg, sel = scheduler.plan_next_iteration(bar_report, [])        
+        self.assertEqual(conv, False)
+        self.assertTrue(isinstance(ltg, MockedExplorationTaskGroup1))
+        self.assertTrue(isinstance(sel, ConfSelectorFrames))
+        self.assertEqual(sel.report.trust_level.level_f_lo, 0.2)
+        self.assertEqual(sel.report.trust_level.level_f_hi, 0.4)
+        self.assertTrue(sel.report.trust_level.level_v_lo is None)
+        self.assertTrue(sel.report.trust_level.level_v_hi is None)
+        self.assertEqual(scheduler.get_stage(), 1)
+        self.assertEqual(scheduler.get_iteration(), 1)
+        self.assertEqual(len(scheduler.stage_schedulers), 2)
+        self.assertTrue(scheduler.stage_schedulers[0].converged())
+        self.assertTrue(scheduler.stage_schedulers[0].complete())
+        self.assertFalse(scheduler.stage_schedulers[1].converged())
+        self.assertFalse(scheduler.stage_schedulers[1].complete())
+        self.assertFalse(scheduler.complete())
+        conv, ltg, sel = scheduler.plan_next_iteration(foo_report)
+        self.assertEqual(conv, False)
+        self.assertTrue(isinstance(ltg, MockedExplorationTaskGroup1))
+        self.assertTrue(isinstance(sel, ConfSelectorFrames))
+        self.assertEqual(sel.report.trust_level.level_f_lo, 0.2)
+        self.assertEqual(sel.report.trust_level.level_f_hi, 0.4)
+        self.assertTrue(sel.report.trust_level.level_v_lo is None)
+        self.assertTrue(sel.report.trust_level.level_v_hi is None)
+        self.assertEqual(scheduler.get_stage(), 1)
+        self.assertEqual(scheduler.get_iteration(), 2)
+        self.assertEqual(len(scheduler.stage_schedulers), 2)
+        self.assertTrue(scheduler.stage_schedulers[0].converged())
+        self.assertTrue(scheduler.stage_schedulers[0].complete())
+        self.assertFalse(scheduler.stage_schedulers[1].converged())
+        self.assertFalse(scheduler.stage_schedulers[1].complete())
+
+        scheduler_new = copy_scheduler_plans(scheduler_new, scheduler)
+
+        self.assertEqual(scheduler.get_iteration(), scheduler_new.get_iteration())
+        self.assertEqual(scheduler.get_stage(), scheduler_new.get_stage())
+        self.assertEqual(scheduler.complete(), scheduler_new.complete())
+        self.assertEqual(scheduler.print_convergence(), scheduler_new.print_convergence())
+
+
+    def test_copy_scheduler_complete(self):
+        scheduler = ExplorationScheduler()
+        scheduler_new = ExplorationScheduler()
+        trust_level = TrustLevel(0.1, 0.3)
+        report = ExplorationReportTrustLevels(trust_level, 0.9)
+        traj_render = TrajRenderLammps()        
+        selector = ConfSelectorFrames(traj_render, report)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage(),
+            selector,
+            max_numb_iter = 1,
+            fatal_at_max = False,
+        )
+        scheduler.add_stage_scheduler(stage_scheduler)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage(),
+            selector,
+            max_numb_iter = 2,
+        )
+        scheduler_new.add_stage_scheduler(stage_scheduler)
+
+        trust_level = TrustLevel(0.2, 0.4)
+        report = ExplorationReportTrustLevels(trust_level, 0.9)
+        traj_render = TrajRenderLammps()        
+        selector = ConfSelectorFrames(traj_render, report)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage1(),
+            selector,
+            max_numb_iter = 3,
+        )
+        scheduler.add_stage_scheduler(stage_scheduler)
+        stage_scheduler = ConvergenceCheckStageScheduler(
+            MockedStage1(),
+            selector,
+            max_numb_iter = 3,
+        )
+        scheduler_new.add_stage_scheduler(stage_scheduler)
+
+        foo_report = MockedExplorationReport()
+        foo_report.accurate = 0.5
+        foo_report.failed = 0.5          
+        bar_report = MockedExplorationReport()
+        bar_report.accurate = 1.0
+        bar_report.failed = 0.0        
+        
+        conv, ltg, sel = scheduler.plan_next_iteration()
+        self.assertEqual(conv, False)
+        self.assertTrue(isinstance(ltg, MockedExplorationTaskGroup))
+        self.assertTrue(isinstance(sel, ConfSelectorFrames))
+        self.assertEqual(sel.report.trust_level.level_f_lo, 0.1)
+        self.assertEqual(sel.report.trust_level.level_f_hi, 0.3)
+        self.assertTrue(sel.report.trust_level.level_v_lo is None)
+        self.assertTrue(sel.report.trust_level.level_v_hi is None)
+        self.assertEqual(scheduler.get_stage(), 0)
+        self.assertEqual(scheduler.get_iteration(), 0)
+        self.assertEqual(len(scheduler.stage_schedulers), 2)
+        self.assertFalse(scheduler.stage_schedulers[0].converged())
+        conv, ltg, sel = scheduler.plan_next_iteration(foo_report, [])        
+        self.assertEqual(conv, False)
+        self.assertTrue(isinstance(ltg, MockedExplorationTaskGroup1))
+        self.assertTrue(isinstance(sel, ConfSelectorFrames))
+        self.assertEqual(sel.report.trust_level.level_f_lo, 0.2)
+        self.assertEqual(sel.report.trust_level.level_f_hi, 0.4)
+        self.assertTrue(sel.report.trust_level.level_v_lo is None)
+        self.assertTrue(sel.report.trust_level.level_v_hi is None)
+        self.assertEqual(scheduler.get_stage(), 1)
+        self.assertEqual(scheduler.get_iteration(), 1)
+        self.assertEqual(len(scheduler.stage_schedulers), 2)
+        self.assertFalse(scheduler.stage_schedulers[0].converged())
+        self.assertTrue(scheduler.stage_schedulers[0].complete())
+        self.assertFalse(scheduler.stage_schedulers[1].converged())
+        self.assertFalse(scheduler.stage_schedulers[1].complete())
+        self.assertFalse(scheduler.complete())
+        conv, ltg, sel = scheduler.plan_next_iteration(foo_report)
+        self.assertEqual(conv, False)
+        self.assertTrue(isinstance(ltg, MockedExplorationTaskGroup1))
+        self.assertTrue(isinstance(sel, ConfSelectorFrames))
+        self.assertEqual(sel.report.trust_level.level_f_lo, 0.2)
+        self.assertEqual(sel.report.trust_level.level_f_hi, 0.4)
+        self.assertTrue(sel.report.trust_level.level_v_lo is None)
+        self.assertTrue(sel.report.trust_level.level_v_hi is None)
+        self.assertEqual(scheduler.get_stage(), 1)
+        self.assertEqual(scheduler.get_iteration(), 2)
+        self.assertEqual(len(scheduler.stage_schedulers), 2)
+        self.assertFalse(scheduler.stage_schedulers[0].converged())
+        self.assertTrue(scheduler.stage_schedulers[0].complete())
+        self.assertFalse(scheduler.stage_schedulers[1].converged())
+        self.assertFalse(scheduler.stage_schedulers[1].complete())
+
+        scheduler_new = copy_scheduler_plans(scheduler_new, scheduler)
+
+        self.assertEqual(scheduler.get_iteration(), scheduler_new.get_iteration())
+        self.assertEqual(scheduler.get_stage(), scheduler_new.get_stage())
+        self.assertEqual(scheduler.complete(), scheduler_new.complete())
+        self.assertEqual(scheduler.print_convergence(), scheduler_new.print_convergence())

--- a/tests/entrypoint/test_submit.py
+++ b/tests/entrypoint/test_submit.py
@@ -203,8 +203,8 @@ class TestSubmit(unittest.TestCase):
 
         scheduler_new = copy_scheduler_plans(scheduler_new, scheduler)
 
-        self.assertEqual(scheduler.get_iteration(), scheduler_new.get_iteration())
         self.assertEqual(scheduler.get_stage(), scheduler_new.get_stage())
+        self.assertEqual(scheduler.get_iteration(), scheduler_new.get_iteration())
         self.assertEqual(scheduler.complete(), scheduler_new.complete())
         self.assertEqual(scheduler.print_convergence(), scheduler_new.print_convergence())
 
@@ -303,4 +303,9 @@ class TestSubmit(unittest.TestCase):
         self.assertEqual(scheduler.get_iteration(), scheduler_new.get_iteration())
         self.assertEqual(scheduler.get_stage(), scheduler_new.get_stage())
         self.assertEqual(scheduler.complete(), scheduler_new.complete())
-        self.assertEqual(scheduler.print_convergence(), scheduler_new.print_convergence())
+        # 1st stage of scheduler_new is forced complete.
+        self.assertEqual(
+            scheduler.print_convergence().replace(
+            'reached max numb iterations YES',
+            'reached max numb iterations NO ',),
+            scheduler_new.print_convergence())

--- a/tests/exploration/test_exploration_scheduler.py
+++ b/tests/exploration/test_exploration_scheduler.py
@@ -236,52 +236,107 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_print_scheduler(self):
         scheduler = ExplorationScheduler()        
-        trust_level = TrustLevel(0.1, 0.3)
-        report = ExplorationReportTrustLevels(trust_level, 0.9)
-        traj_render = TrajRenderLammps()        
-        selector = ConfSelectorFrames(traj_render, report)
-        stage_scheduler = ConvergenceCheckStageScheduler(
+        trust_level_0 = TrustLevel(0.1, 0.3)
+        report_0 = ExplorationReportTrustLevels(trust_level_0, 0.9)
+        traj_render_0 = TrajRenderLammps()        
+        selector_0 = ConfSelectorFrames(traj_render_0, report_0)
+        stage_scheduler_0 = ConvergenceCheckStageScheduler(
             MockedStage(),
-            selector,
+            selector_0,
             max_numb_iter = 2,
         )
-        scheduler.add_stage_scheduler(stage_scheduler)
-        trust_level = TrustLevel(0.2, 0.4)
-        report = ExplorationReportTrustLevels(trust_level, 0.9)
-        traj_render = TrajRenderLammps()        
-        selector = ConfSelectorFrames(traj_render, report)
-        stage_scheduler = ConvergenceCheckStageScheduler(
+        scheduler.add_stage_scheduler(stage_scheduler_0)
+        trust_level_1 = TrustLevel(0.2, 0.4)
+        report_1 = ExplorationReportTrustLevels(trust_level_1, 0.9)
+        traj_render_1 = TrajRenderLammps()        
+        selector_1 = ConfSelectorFrames(traj_render_1, report_1)
+        stage_scheduler_1 = ConvergenceCheckStageScheduler(
             MockedStage1(),
-            selector,
+            selector_1,
             max_numb_iter = 2,
         )
-        scheduler.add_stage_scheduler(stage_scheduler)
+        scheduler.add_stage_scheduler(stage_scheduler_1)
 
-        foo_report = ExplorationReportTrustLevels(trust_level, 0.9)
+        tar_report = ExplorationReportTrustLevels(trust_level_0, 0.9)
+        tar_report.record([ np.array([0.08, 0.05]) ])
+        foo_report = ExplorationReportTrustLevels(trust_level_1, 0.9)
         foo_report.record([ np.array([0.3, 0.9]) ])
-        bar_report = ExplorationReportTrustLevels(trust_level, 0.9)
+        bar_report = ExplorationReportTrustLevels(trust_level_1, 0.9)
         bar_report.record([ np.array([0.1, 0.1]) ])
 
         expected_output = [
-            '#   stage  id_stg.    iter.      accu.      cand.      fail.',
+            '#   stage  id_stg.    iter.      accu.      cand.      fail.   lvl_f_lo   lvl_f_hi    cvged',
             '# Stage    0  --------------------',
-            '        0        0        0     1.0000     0.0000     0.0000',
+            '        0        0        0     1.0000     0.0000     0.0000     0.1000     0.3000     True',
             '# Stage    0  converged YES  reached max numb iterations NO ',
             '# Stage    1  --------------------',
-            '        1        0        1     0.0000     0.5000     0.5000',
-            '        1        1        2     1.0000     0.0000     0.0000',
+            '        1        0        1     0.0000     0.5000     0.5000     0.2000     0.4000    False',
+            '        1        1        2     1.0000     0.0000     0.0000     0.2000     0.4000     True',
             '# Stage    1  converged YES  reached max numb iterations NO ',
             '# All stages converged',
         ]
         self.assertEqual(scheduler.print_convergence(), "No finished iteration found\n")
         conv, ltg, sel = scheduler.plan_next_iteration()
         self.assertEqual(scheduler.print_convergence(), "No finished iteration found\n")
-        conv, ltg, sel = scheduler.plan_next_iteration(bar_report, [])        
+        conv, ltg, sel = scheduler.plan_next_iteration(tar_report, [])        
         self.assertEqual(scheduler.print_convergence(), '\n'.join(expected_output[:3])+'\n')
         conv, ltg, sel = scheduler.plan_next_iteration(foo_report, [])
         self.assertEqual(scheduler.print_convergence(), '\n'.join(expected_output[:6])+'\n')
         conv, ltg, sel = scheduler.plan_next_iteration(bar_report, [])
         self.assertEqual(scheduler.print_convergence(), '\n'.join(expected_output)+'\n')
+
+
+    def test_print_scheduler_last_iteration(self):
+        scheduler = ExplorationScheduler()        
+        trust_level_0 = TrustLevel(0.1, 0.3)
+        report_0 = ExplorationReportTrustLevels(trust_level_0, 0.9)
+        traj_render_0 = TrajRenderLammps()        
+        selector_0 = ConfSelectorFrames(traj_render_0, report_0)
+        stage_scheduler_0 = ConvergenceCheckStageScheduler(
+            MockedStage(),
+            selector_0,
+            max_numb_iter = 2,
+        )
+        scheduler.add_stage_scheduler(stage_scheduler_0)
+        trust_level_1 = TrustLevel(0.2, 0.4)
+        report_1 = ExplorationReportTrustLevels(trust_level_1, 0.9)
+        traj_render_1 = TrajRenderLammps()        
+        selector_1 = ConfSelectorFrames(traj_render_1, report_1)
+        stage_scheduler_1 = ConvergenceCheckStageScheduler(
+            MockedStage1(),
+            selector_1,
+            max_numb_iter = 2,
+        )
+        scheduler.add_stage_scheduler(stage_scheduler_1)
+
+        tar_report = ExplorationReportTrustLevels(trust_level_0, 0.9)
+        tar_report.record([ np.array([0.08, 0.05]) ])
+        foo_report = ExplorationReportTrustLevels(trust_level_1, 0.9)
+        foo_report.record([ np.array([0.3, 0.9]) ])
+        bar_report = ExplorationReportTrustLevels(trust_level_1, 0.9)
+        bar_report.record([ np.array([0.1, 0.1]) ])
+
+        expected_output = [
+            '#   stage  id_stg.    iter.      accu.      cand.      fail.   lvl_f_lo   lvl_f_hi    cvged',
+            '        0        0        0     1.0000     0.0000     0.0000     0.1000     0.3000     True',
+            '        1        0        1     0.0000     0.5000     0.5000     0.2000     0.4000    False',
+            '        1        1        2     1.0000     0.0000     0.0000     0.2000     0.4000     True',
+            '# All stages converged',
+        ]
+        self.assertEqual(scheduler.print_last_iteration(),
+                         "No finished iteration found\n")
+        conv, ltg, sel = scheduler.plan_next_iteration()
+        self.assertEqual(scheduler.print_last_iteration(),
+                         "No finished iteration found\n")
+        conv, ltg, sel = scheduler.plan_next_iteration(tar_report, [])        
+        self.assertEqual(scheduler.print_last_iteration(print_header=True),
+                         '\n'.join(expected_output[:2])+'\n')
+        conv, ltg, sel = scheduler.plan_next_iteration(foo_report, [])
+        self.assertEqual(scheduler.print_last_iteration(),
+                         '\n'.join(expected_output[2:3])+'\n')
+        conv, ltg, sel = scheduler.plan_next_iteration(bar_report, [])
+        self.assertEqual(scheduler.print_last_iteration(),
+                         '\n'.join(expected_output[3:])+'\n')
 
 
     def test_success_and_ratios(self):

--- a/tests/mocked_ops.py
+++ b/tests/mocked_ops.py
@@ -634,11 +634,18 @@ class MockedExplorationReport(ExplorationReport):
     def record(self, mdf, mdv):
         raise NotImplementedError
 
-    def print(self):
-        raise NotImplementedError
+    def print(
+            self, 
+            stage_idx : int,
+            idx_in_stage : int,
+            iter_idx : int,
+    ):
+        # raise NotImplementedError
+        return f'{self.failed} {self.candidate} {self.accurate} {self.conv_accuracy}'
 
     def print_header(self):
-        raise NotImplementedError
+        # raise NotImplementedError
+        return 'header'
 
     def converged(self):
         return self.accurate >= self.conv_accuracy

--- a/tests/utils/test_dflow_query.py
+++ b/tests/utils/test_dflow_query.py
@@ -32,6 +32,7 @@ from dpgen2.utils.dflow_query import (
     get_iteration,
     matched_step_key,
     get_last_iteration,
+    get_all_schedulers,
     find_slice_ranges,
     sort_slice_ops,
     print_keys_in_nice_format,
@@ -88,20 +89,28 @@ dpgen_keys = [
 ]
 
 class MockedTar:
-    value = 10
+    def __init__(self):
+        self.value = 10
 
 class MockedFoo:
-    parameters = {
-        'exploration_scheduler' : MockedTar()
-    }
+    def __init__(self):
+        self.parameters = {
+            'exploration_scheduler' : MockedTar()
+        }
 
 class MockedBar:
-    outputs = MockedFoo        
+    def __init__(self, xx):
+        self.outputs = MockedFoo()
+        self.outputs.parameters['exploration_scheduler'].value = xx*10
 
 class MockedWF:
     def query_step(self,key=None):
-        assert(key == 'iter1--scheduler')
-        return [MockedBar()]
+        if key == 'iter-0--scheduler':
+            return [MockedBar(0)]
+        elif key == 'iter-1--scheduler':
+            return [MockedBar(1)]
+        else:
+            raise RuntimeError('unexpected key')
 
 class TestDflowQuery(unittest.TestCase):
     def test_get_subkey(self):
@@ -124,9 +133,17 @@ class TestDflowQuery(unittest.TestCase):
     def test_get_last_scheduler(self):
         value = get_last_scheduler(
             MockedWF(), 
-            ['iter1--scheduler', 'foo', 'bar', 'iter0--scheduler', 'init--scheduler'],
+            ['iter-1--scheduler', 'foo', 'bar', 'iter-0--scheduler', 'init--scheduler'],
         )
         self.assertEqual(value, 10)
+
+
+    def test_get_all_schedulers(self):
+        value = get_all_schedulers(
+            MockedWF(), 
+            ['iter-1--scheduler', 'foo', 'bar', 'iter-0--scheduler', 'init--scheduler'],
+        )
+        self.assertEqual(value, [0, 10])
 
     def test_get_last_iteration(self):
         last = get_last_iteration(dpgen_keys)

--- a/tests/utils/test_dflow_query.py
+++ b/tests/utils/test_dflow_query.py
@@ -105,7 +105,9 @@ class MockedBar:
 
 class MockedWF:
     def query_step(self,key=None):
-        if key == 'iter-0--scheduler':
+        if key == 'init--scheduler':
+            return [MockedBar(2)]
+        elif key == 'iter-0--scheduler':
             return [MockedBar(0)]
         elif key == 'iter-1--scheduler':
             return [MockedBar(1)]
@@ -143,7 +145,7 @@ class TestDflowQuery(unittest.TestCase):
             MockedWF(), 
             ['iter-1--scheduler', 'foo', 'bar', 'iter-0--scheduler', 'init--scheduler'],
         )
-        self.assertEqual(value, [0, 10])
+        self.assertEqual(value, [20, 0, 10])
 
     def test_get_last_iteration(self):
         last = get_last_iteration(dpgen_keys)


### PR DESCRIPTION
When resubmit, update the scheduler of the old workflow. Otherwise the workflow will exactly follow the old schedule and one has no opportunity to update the schedule. 

Also update the report printing:  print the trust levels and if the iteration is converged. 