### PR TITLE
Dflow debug mode for dpgen2

### DIFF
--- a/dpgen2/entrypoint/common.py
+++ b/dpgen2/entrypoint/common.py
@@ -26,7 +26,7 @@ def global_config_workflow(
     # dflow_config, dflow_s3_config
     workflow_config_from_dict(wf_config)
 
-    if os.getenv('DFLOW_DEBUG'):
+    if os.getenv("DFLOW_DEBUG"):
         dflow.config["mode"] = "debug"
         return None
 

--- a/dpgen2/entrypoint/common.py
+++ b/dpgen2/entrypoint/common.py
@@ -1,5 +1,6 @@
 import dflow
 from pathlib import Path
+import os
 from dpgen2.utils import (
     dump_object_to_file,
     load_object_from_file,
@@ -24,6 +25,10 @@ def global_config_workflow(
 ):
     # dflow_config, dflow_s3_config
     workflow_config_from_dict(wf_config)
+
+    if os.getenv('DFLOW_DEBUG'):
+        dflow.config["mode"] = "debug"
+        return None
 
     # lebesgue context
     lebesgue_context = None

--- a/dpgen2/utils/bohrium_config.py
+++ b/dpgen2/utils/bohrium_config.py
@@ -7,10 +7,6 @@ import os
 def bohrium_config_from_dict(
     bohrium_config,
 ):
-    if os.getenv('DFLOW_DEBUG'):
-        config["mode"] = "debug"
-        return
-
     config["host"] = bohrium_config["host"]
     config["k8s_api_server"] = bohrium_config["k8s_api_server"]
     bohrium.config["username"] = bohrium_config["username"]

--- a/dpgen2/utils/bohrium_config.py
+++ b/dpgen2/utils/bohrium_config.py
@@ -1,11 +1,16 @@
 import dflow, importlib
 from dflow import config, s3_config
 from dflow.plugins import bohrium
+import os
 
 
 def bohrium_config_from_dict(
     bohrium_config,
 ):
+    if os.getenv('DFLOW_DEBUG'):
+        config["mode"] = "debug"
+        return
+
     config["host"] = bohrium_config["host"]
     config["k8s_api_server"] = bohrium_config["k8s_api_server"]
     bohrium.config["username"] = bohrium_config["username"]

--- a/dpgen2/utils/run_command.py
+++ b/dpgen2/utils/run_command.py
@@ -1,4 +1,5 @@
 from dflow.utils import run_command as dflow_run_command
+from dflow import config
 from typing import Tuple, Union, List
 import os
 
@@ -7,7 +8,7 @@ def run_command(
     cmd: Union[str, List[str]],
     shell: bool = False,
 ) -> Tuple[int, str, str]:
-    interactive = False if os.getenv('DFLOW_DEBUG') else True
+    interactive = False if config["mode"] == "debug" else True
     return dflow_run_command(
         cmd,
         raise_error=False,

--- a/dpgen2/utils/run_command.py
+++ b/dpgen2/utils/run_command.py
@@ -1,13 +1,16 @@
 from dflow.utils import run_command as dflow_run_command
 from typing import Tuple, Union, List
+import os
 
 
 def run_command(
     cmd: Union[str, List[str]],
     shell: bool = False,
 ) -> Tuple[int, str, str]:
+    interactive = False if os.getenv('DFLOW_DEBUG') else True
     return dflow_run_command(
         cmd,
         raise_error=False,
         try_bash=shell,
+        interactive=interactive
     )

--- a/dpgen2/utils/step_config.py
+++ b/dpgen2/utils/step_config.py
@@ -6,6 +6,7 @@ from dargs import (
 from dpgen2.constants import default_image
 from dflow.plugins.lebesgue import LebesgueExecutor
 from dflow.plugins.dispatcher import DispatcherExecutor
+import os
 
 
 def lebesgue_extra_args():
@@ -160,7 +161,7 @@ def gen_doc(*, make_anchor=True, make_link=True, **kwargs):
 def init_executor(
     executor_dict,
 ):
-    if executor_dict is None:
+    if executor_dict is None or os.getenv('DFLOW_DEBUG') is not None:
         return None
     etype = executor_dict.pop("type")
     if etype == "lebesgue_v2":

--- a/dpgen2/utils/step_config.py
+++ b/dpgen2/utils/step_config.py
@@ -6,6 +6,7 @@ from dargs import (
 from dpgen2.constants import default_image
 from dflow.plugins.lebesgue import LebesgueExecutor
 from dflow.plugins.dispatcher import DispatcherExecutor
+from dflow import config
 import os
 
 
@@ -161,7 +162,7 @@ def gen_doc(*, make_anchor=True, make_link=True, **kwargs):
 def init_executor(
     executor_dict,
 ):
-    if executor_dict is None or os.getenv('DFLOW_DEBUG') is not None:
+    if executor_dict is None or config["mode"] == "debug":
         return None
     etype = executor_dict.pop("type")
     if etype == "lebesgue_v2":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
 	     'numpy',
 	     'dpdata',
-	     'pydflow>=1.6.30',
+	     'pydflow>=1.6.33',
 	     'dargs>=0.3.1',
 	     'scipy',
 	     'lbg',

--- a/tests/utils/test_step_config.py
+++ b/tests/utils/test_step_config.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 
 
 @contextmanager
-def dflow_mode(mode: str = 'default'):
+def dflow_mode(mode: str = "default"):
     _mode = dflow.config["mode"]
     dflow.config["mode"] = mode
     try:
@@ -102,14 +102,13 @@ class TestStepConfig(unittest.TestCase):
             },
         }
         odict = normalize(idict)
-        with dflow_mode('debug'):
+        with dflow_mode("debug"):
             ret = init_executor(deepcopy(odict).pop("executor"))
             self.assertTrue(ret is None)
 
-        with dflow_mode('default'):
+        with dflow_mode("default"):
             ret = init_executor(deepcopy(odict).pop("executor"))
             self.assertTrue(isinstance(ret, dflow.plugins.lebesgue.LebesgueExecutor))
-
 
     def test_init_executor_notype(self):
         idict = {
@@ -130,10 +129,12 @@ class TestStepConfig(unittest.TestCase):
         }
         odict = normalize(idict)
         self.assertEqual(odict["executor"], idict["executor"])
-        with dflow_mode('debug'):
+        with dflow_mode("debug"):
             ret = init_executor(deepcopy(odict).pop("executor"))
             self.assertTrue(ret is None)
 
-        with dflow_mode('default'):
+        with dflow_mode("default"):
             ret = init_executor(deepcopy(odict).pop("executor"))
-            self.assertTrue(isinstance(ret, dflow.plugins.dispatcher.DispatcherExecutor))
+            self.assertTrue(
+                isinstance(ret, dflow.plugins.dispatcher.DispatcherExecutor)
+            )

--- a/tests/utils/test_step_config.py
+++ b/tests/utils/test_step_config.py
@@ -14,6 +14,13 @@ import dflow
 
 
 class TestStepConfig(unittest.TestCase):
+    def setUp(self):
+        self.DFLOW_DEBUG = os.environ.pop('DFLOW_DEBUG', None)
+
+    def tearDown(self):
+        if self.DFLOW_DEBUG:
+            os.environ['DFLOW_DEBUG'] = self.DFLOW_DEBUG
+
     def test_success(self):
         idict = {
             "template_config": {

--- a/tests/utils/test_step_config.py
+++ b/tests/utils/test_step_config.py
@@ -21,13 +21,13 @@ from copy import deepcopy
 
 
 @contextmanager
-def disable_debug_mode():
-    DFLOW_DEBUG = os.environ.pop('DFLOW_DEBUG', None)
+def dflow_mode(mode: str = 'default'):
+    _mode = dflow.config["mode"]
+    dflow.config["mode"] = mode
     try:
         yield
     finally:
-        if DFLOW_DEBUG:
-            os.environ['DFLOW_DEBUG'] = DFLOW_DEBUG
+        dflow.config["mode"] = _mode
 
 
 class TestStepConfig(unittest.TestCase):
@@ -103,12 +103,14 @@ class TestStepConfig(unittest.TestCase):
             },
         }
         odict = normalize(idict)
-        with disable_debug_mode():
+        with dflow_mode('debug'):
+            ret = init_executor(deepcopy(odict).pop("executor"))
+            self.assertTrue(ret is None)
+
+        with dflow_mode('default'):
             ret = init_executor(deepcopy(odict).pop("executor"))
             self.assertTrue(isinstance(ret, dflow.plugins.lebesgue.LebesgueExecutor))
 
-        ret = init_executor(deepcopy(odict).pop("executor"))
-        self.assertTrue(ret is None)
 
     def test_init_executor_notype(self):
         idict = {
@@ -129,9 +131,10 @@ class TestStepConfig(unittest.TestCase):
         }
         odict = normalize(idict)
         self.assertEqual(odict["executor"], idict["executor"])
-        with disable_debug_mode():
+        with dflow_mode('debug'):
+            ret = init_executor(deepcopy(odict).pop("executor"))
+            self.assertTrue(ret is None)
+
+        with dflow_mode('default'):
             ret = init_executor(deepcopy(odict).pop("executor"))
             self.assertTrue(isinstance(ret, dflow.plugins.dispatcher.DispatcherExecutor))
-        
-        ret = init_executor(deepcopy(odict).pop("executor"))
-        self.assertTrue(ret is None)


### PR DESCRIPTION
Adding dflow debug mode for dpgen2, which is more convenient for `knowledge distillation` in many cases. One can run the program without argo as long as `DeePMD-kit` and `lammps` are installed in local environment.