### PR TITLE
add group_size/pool_size for lmp and fp

### DIFF
--- a/dpgen2/superop/prep_run_fp.py
+++ b/dpgen2/superop/prep_run_fp.py
@@ -125,9 +125,7 @@ def _prep_run_fp(
     run_template_config = run_config.pop("template_config")
     prep_executor = init_executor(prep_config.pop("executor"))
     run_executor = init_executor(run_config.pop("executor"))
-    template_slice_config = run_config.pop("template_slice_config", None)
-    group_size = template_slice_config.get("group_size", None) if template_slice_config else None
-    pool_size = template_slice_config.get("pool_size", None) if template_slice_config else None
+    template_slice_config = run_config.pop("template_slice_config", {})
 
     prep_fp = Step(
         "prep-fp",
@@ -159,8 +157,7 @@ def _prep_run_fp(
                 input_parameter=["task_name"],
                 input_artifact=["task_path"],
                 output_artifact=["log", "labeled_data"],
-                pool_size=pool_size,
-                group_size=group_size,
+                **template_slice_config
             ),
             python_packages=upload_python_packages,
             **run_template_config,

--- a/dpgen2/superop/prep_run_fp.py
+++ b/dpgen2/superop/prep_run_fp.py
@@ -148,7 +148,7 @@ def _prep_run_fp(
         **prep_config,
     )
     prep_run_steps.add(prep_fp)
-    
+
     run_fp = Step(
         "run-fp",
         template=PythonOPTemplate(
@@ -159,7 +159,7 @@ def _prep_run_fp(
                 input_artifact=["task_path"],
                 output_artifact=["log", "labeled_data"],
                 pool_size=pool_size,
-                group_size=group_size
+                group_size=group_size,
             ),
             python_packages=upload_python_packages,
             **run_template_config,

--- a/dpgen2/superop/prep_run_fp.py
+++ b/dpgen2/superop/prep_run_fp.py
@@ -125,6 +125,8 @@ def _prep_run_fp(
     run_template_config = run_config.pop("template_config")
     prep_executor = init_executor(prep_config.pop("executor"))
     run_executor = init_executor(run_config.pop("executor"))
+    group_size = run_config.pop("group_size") if "group_size" in run_config else None
+    pool_size = run_config.pop("pool_size") if "pool_size" in run_config else None
 
     prep_fp = Step(
         "prep-fp",
@@ -146,7 +148,7 @@ def _prep_run_fp(
         **prep_config,
     )
     prep_run_steps.add(prep_fp)
-
+    
     run_fp = Step(
         "run-fp",
         template=PythonOPTemplate(
@@ -156,6 +158,8 @@ def _prep_run_fp(
                 input_parameter=["task_name"],
                 input_artifact=["task_path"],
                 output_artifact=["log", "labeled_data"],
+                pool_size=pool_size,
+                group_size=group_size
             ),
             python_packages=upload_python_packages,
             **run_template_config,

--- a/dpgen2/superop/prep_run_fp.py
+++ b/dpgen2/superop/prep_run_fp.py
@@ -125,8 +125,9 @@ def _prep_run_fp(
     run_template_config = run_config.pop("template_config")
     prep_executor = init_executor(prep_config.pop("executor"))
     run_executor = init_executor(run_config.pop("executor"))
-    group_size = run_config.pop("group_size") if "group_size" in run_config else None
-    pool_size = run_config.pop("pool_size") if "pool_size" in run_config else None
+    template_slice_config = run_config.pop("template_slice_config", None)
+    group_size = template_slice_config.get("group_size", None) if template_slice_config else None
+    pool_size = template_slice_config.get("pool_size", None) if template_slice_config else None
 
     prep_fp = Step(
         "prep-fp",

--- a/dpgen2/superop/prep_run_fp.py
+++ b/dpgen2/superop/prep_run_fp.py
@@ -157,7 +157,7 @@ def _prep_run_fp(
                 input_parameter=["task_name"],
                 input_artifact=["task_path"],
                 output_artifact=["log", "labeled_data"],
-                **template_slice_config
+                **template_slice_config,
             ),
             python_packages=upload_python_packages,
             **run_template_config,

--- a/dpgen2/superop/prep_run_lmp.py
+++ b/dpgen2/superop/prep_run_lmp.py
@@ -156,9 +156,9 @@ def _prep_run_lmp(
             run_op,
             slices=Slices(
                 "int('{{item}}')",
-                input_parameter = ["task_name"],
-                input_artifact = ["task_path"],
-                output_artifact = ["log", "traj", "model_devi", "plm_output"],
+                input_parameter=["task_name"],
+                input_artifact=["task_path"],
+                output_artifact=["log", "traj", "model_devi", "plm_output"],
                 pool_size=pool_size,
                 group_size=group_size
             ),
@@ -166,19 +166,19 @@ def _prep_run_lmp(
             **run_template_config,
         ),
         parameters={
-            "task_name" : prep_lmp.outputs.parameters["task_names"],
-            "config" : prep_run_steps.inputs.parameters["lmp_config"]
+            "task_name": prep_lmp.outputs.parameters["task_names"],
+            "config": prep_run_steps.inputs.parameters["lmp_config"]
         },
         artifacts={
-            "task_path" : prep_lmp.outputs.artifacts["task_paths"],
-            "models" : prep_run_steps.inputs.artifacts["models"],
+            "task_path": prep_lmp.outputs.artifacts["task_paths"],
+            "models": prep_run_steps.inputs.artifacts["models"],
         },
         with_sequence=argo_sequence(
             argo_len(prep_lmp.outputs.parameters["task_names"]),
             format=lmp_index_pattern,
         ),
-        key = step_keys["run-lmp"],
-        executor = run_executor,
+        key=step_keys["run-lmp"],
+        executor=run_executor,
         **run_config,
     )
     prep_run_steps.add(run_lmp)

--- a/dpgen2/superop/prep_run_lmp.py
+++ b/dpgen2/superop/prep_run_lmp.py
@@ -160,14 +160,14 @@ def _prep_run_lmp(
                 input_artifact=["task_path"],
                 output_artifact=["log", "traj", "model_devi", "plm_output"],
                 pool_size=pool_size,
-                group_size=group_size
+                group_size=group_size,
             ),
             python_packages=upload_python_packages,
             **run_template_config,
         ),
         parameters={
             "task_name": prep_lmp.outputs.parameters["task_names"],
-            "config": prep_run_steps.inputs.parameters["lmp_config"]
+            "config": prep_run_steps.inputs.parameters["lmp_config"],
         },
         artifacts={
             "task_path": prep_lmp.outputs.artifacts["task_paths"],

--- a/dpgen2/superop/prep_run_lmp.py
+++ b/dpgen2/superop/prep_run_lmp.py
@@ -129,9 +129,7 @@ def _prep_run_lmp(
     run_template_config = run_config.pop("template_config")
     prep_executor = init_executor(prep_config.pop("executor"))
     run_executor = init_executor(run_config.pop("executor"))
-    template_slice_config = run_config.pop("template_slice_config", None)
-    group_size = template_slice_config.get("group_size", None) if template_slice_config else None
-    pool_size = template_slice_config.get("pool_size", None) if template_slice_config else None
+    template_slice_config = run_config.pop("template_slice_config", {})
 
     prep_lmp = Step(
         "prep-lmp",
@@ -160,8 +158,7 @@ def _prep_run_lmp(
                 input_parameter=["task_name"],
                 input_artifact=["task_path"],
                 output_artifact=["log", "traj", "model_devi", "plm_output"],
-                pool_size=pool_size,
-                group_size=group_size,
+                **template_slice_config
             ),
             python_packages=upload_python_packages,
             **run_template_config,

--- a/dpgen2/superop/prep_run_lmp.py
+++ b/dpgen2/superop/prep_run_lmp.py
@@ -129,8 +129,9 @@ def _prep_run_lmp(
     run_template_config = run_config.pop("template_config")
     prep_executor = init_executor(prep_config.pop("executor"))
     run_executor = init_executor(run_config.pop("executor"))
-    group_size = run_config.pop("group_size") if "group_size" in run_config else None
-    pool_size = run_config.pop("pool_size") if "pool_size" in run_config else None
+    template_slice_config = run_config.pop("template_slice_config", None)
+    group_size = template_slice_config.get("group_size", None) if template_slice_config else None
+    pool_size = template_slice_config.get("pool_size", None) if template_slice_config else None
 
     prep_lmp = Step(
         "prep-lmp",

--- a/dpgen2/superop/prep_run_lmp.py
+++ b/dpgen2/superop/prep_run_lmp.py
@@ -158,7 +158,7 @@ def _prep_run_lmp(
                 input_parameter=["task_name"],
                 input_artifact=["task_path"],
                 output_artifact=["log", "traj", "model_devi", "plm_output"],
-                **template_slice_config
+                **template_slice_config,
             ),
             python_packages=upload_python_packages,
             **run_template_config,

--- a/dpgen2/utils/step_config.py
+++ b/dpgen2/utils/step_config.py
@@ -83,6 +83,7 @@ def template_conf_args():
         Argument("envs", dict, optional=True, default=None, doc=doc_envs),
     ]
 
+
 def template_slice_conf_args():
     doc_group_size = "The number of tasks running on a single node. It is efficient for a large number of short tasks."
     doc_pool_size = "The number of tasks running at the same time on one node."

--- a/dpgen2/utils/step_config.py
+++ b/dpgen2/utils/step_config.py
@@ -83,9 +83,18 @@ def template_conf_args():
         Argument("envs", dict, optional=True, default=None, doc=doc_envs),
     ]
 
+def template_slice_conf_args():
+    doc_group_size = "The number of tasks running on a single node. It is efficient for a large number of short tasks."
+    doc_pool_size = "The number of tasks running at the same time on one node."
+    return [
+        Argument("group_size", int, optional=True, default=None, doc=doc_group_size),
+        Argument("pool_size", int, optional=True, default=None, doc=doc_pool_size),
+    ]
+
 
 def step_conf_args():
     doc_template = "The configs passed to the PythonOPTemplate."
+    doc_template_slice = "The configs passed to the Slices."
     doc_executor = "The executor of the step."
     doc_continue_on_failed = "If continue the the step is failed (FatalError, TransientError, A certain number of retrial is reached...)."
     doc_continue_on_num_success = "Only in the sliced OP case. Continue the workflow if a certain number of the sliced jobs are successful."
@@ -100,6 +109,13 @@ def step_conf_args():
             optional=True,
             default={"image": default_image},
             doc=doc_template,
+        ),
+        Argument(
+            "template_slice_config",
+            dict,
+            template_slice_conf_args(),
+            optional=True,
+            doc=doc_template_slice,
         ),
         Argument(
             "continue_on_failed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
 	     'numpy',
 	     'dpdata',
-	     'pydflow>=1.6.33',
+	     'pydflow>=1.6.39',
 	     'dargs>=0.3.1',
 	     'scipy',
 	     'lbg',


### PR DESCRIPTION
Adding group_size/pool_size for `lmp` and `fp`. A node can run up to `group_size` tasks and at most `pool_size` tasks are running at the same time.