### PR TITLE
Add maximum selection for ExplorationReportTrustLevels

### DIFF
--- a/dpgen2/entrypoint/submit.py
+++ b/dpgen2/entrypoint/submit.py
@@ -57,7 +57,7 @@ from dpgen2.exploration.render import (
     TrajRenderLammps,
 )
 from dpgen2.exploration.report import (
-    ExplorationReportTrustLevels,
+    ExplorationReportTrustLevelsRandom,
     conv_styles,
 )
 from dpgen2.exploration.scheduler import (

--- a/dpgen2/exploration/report/__init__.py
+++ b/dpgen2/exploration/report/__init__.py
@@ -4,11 +4,17 @@ from .report import (
 from .report_adaptive_lower import (
     ExplorationReportAdaptiveLower,
 )
-from .report_trust_levels import (
-    ExplorationReportTrustLevels,
+
+from .report_trust_levels_max import (
+    ExplorationReportTrustLevelsMax
+)
+
+from .report_trust_levels_random import (
+    ExplorationReportTrustLevelsRandom
 )
 
 conv_styles = {
-    "fixed-levels": ExplorationReportTrustLevels,
+    "fixed-levels": ExplorationReportTrustLevelsRandom,
+    "fixed-levels-max-select": ExplorationReportTrustLevelsMax,
     "adaptive-lower": ExplorationReportAdaptiveLower,
 }

--- a/dpgen2/exploration/report/__init__.py
+++ b/dpgen2/exploration/report/__init__.py
@@ -4,13 +4,11 @@ from .report import (
 from .report_adaptive_lower import (
     ExplorationReportAdaptiveLower,
 )
-
 from .report_trust_levels_max import (
-    ExplorationReportTrustLevelsMax
+    ExplorationReportTrustLevelsMax,
 )
-
 from .report_trust_levels_random import (
-    ExplorationReportTrustLevelsRandom
+    ExplorationReportTrustLevelsRandom,
 )
 
 conv_styles = {

--- a/dpgen2/exploration/report/report_trust_levels_base.py
+++ b/dpgen2/exploration/report/report_trust_levels_base.py
@@ -20,6 +20,8 @@ from . import (
     ExplorationReport,
 )
 
+from abc import abstractmethod
+
 
 class ExplorationReportTrustLevels(ExplorationReport):
     def __init__(
@@ -190,23 +192,13 @@ class ExplorationReportTrustLevels(ExplorationReport):
         self.traj_accu.append(set_accu)
         self.traj_fail.append(set_fail)
 
+    @abstractmethod
     def converged(
         self,
         reports: Optional[List[ExplorationReport]] = None,
     ) -> bool:
         r"""Check if the exploration is converged.
-
-        Parameters
-        ----------
-        reports
-            Historical reports
-
-        Returns
-        -------
-        converged  bool
-            If the exploration is converged.
         """
-        return self.accurate_ratio() >= self.conv_accuracy
 
     def failed_ratio(
         self,
@@ -229,45 +221,13 @@ class ExplorationReportTrustLevels(ExplorationReport):
         traj_nf = [len(ii) for ii in self.traj_cand]
         return float(sum(traj_nf)) / float(sum(self.traj_nframes))
 
+    @abstractmethod
     def get_candidate_ids(
         self,
         max_nframes: Optional[int] = None,
     ) -> List[List[int]]:
-        ntraj = len(self.traj_nframes)
-        id_cand = self._get_candidates(max_nframes)
-        id_cand_list = [[] for ii in range(ntraj)]
-        for ii in id_cand:
-            id_cand_list[ii[0]].append(ii[1])
-        return id_cand_list
+        pass
 
-    def _get_candidates(
-        self,
-        max_nframes: Optional[int] = None,
-    ) -> List[Tuple[int, int]]:
-        """
-        Get candidates. If number of candidates is larger than `max_nframes`,
-        then randomly pick `max_nframes` frames from the candidates.
-
-        Parameters
-        ----------
-        max_nframes
-            The maximal number of frames of candidates.
-
-        Returns
-        -------
-        cand_frames   List[Tuple[int,int]]
-            Candidate frames. A list of tuples: [(traj_idx, frame_idx), ...]
-        """
-        self.traj_cand_picked = []
-        for tidx, tt in enumerate(self.traj_cand):
-            for ff in tt:
-                self.traj_cand_picked.append((tidx, ff))
-        if max_nframes is not None and max_nframes < len(self.traj_cand_picked):
-            random.shuffle(self.traj_cand_picked)
-            ret = sorted(self.traj_cand_picked[:max_nframes])
-        else:
-            ret = self.traj_cand_picked
-        return ret
 
     def print_header(self) -> str:
         r"""Print the header of report"""

--- a/dpgen2/exploration/report/report_trust_levels_base.py
+++ b/dpgen2/exploration/report/report_trust_levels_base.py
@@ -197,8 +197,7 @@ class ExplorationReportTrustLevels(ExplorationReport):
         self,
         reports: Optional[List[ExplorationReport]] = None,
     ) -> bool:
-        r"""Check if the exploration is converged.
-        """
+        pass
 
     def failed_ratio(
         self,

--- a/dpgen2/exploration/report/report_trust_levels_base.py
+++ b/dpgen2/exploration/report/report_trust_levels_base.py
@@ -1,4 +1,7 @@
 import random
+from abc import (
+    abstractmethod,
+)
 from typing import (
     List,
     Optional,
@@ -19,8 +22,6 @@ from ..deviation import (
 from . import (
     ExplorationReport,
 )
-
-from abc import abstractmethod
 
 
 class ExplorationReportTrustLevels(ExplorationReport):
@@ -226,7 +227,6 @@ class ExplorationReportTrustLevels(ExplorationReport):
         max_nframes: Optional[int] = None,
     ) -> List[List[int]]:
         pass
-
 
     def print_header(self) -> str:
         r"""Print the header of report"""

--- a/dpgen2/exploration/report/report_trust_levels_max.py
+++ b/dpgen2/exploration/report/report_trust_levels_max.py
@@ -1,0 +1,89 @@
+import random
+from typing import (
+    List,
+    Optional,
+    Tuple,
+)
+
+import numpy as np
+from dargs import (
+    Argument,
+)
+from dflow.python import (
+    FatalError,
+)
+
+from ..deviation import (
+    DeviManager,
+)
+from . import (
+    ExplorationReport,
+)
+from .report_trust_levels_base import ExplorationReportTrustLevels
+
+
+class ExplorationReportTrustLevelsMax(ExplorationReportTrustLevels):
+
+    def converged(
+        self,
+        reports: Optional[List[ExplorationReport]] = None,
+    ) -> bool:
+        r"""Check if the exploration is converged.
+
+        Parameters
+        ----------
+        reports
+            Historical reports
+
+        Returns
+        -------
+        converged  bool
+            If the exploration is converged.
+        """
+        return self.accurate_ratio() >= self.conv_accuracy
+
+
+    def get_candidate_ids(
+        self,
+        max_nframes: Optional[int] = None,
+    ) -> List[List[int]]:
+        ntraj = len(self.traj_nframes)
+        id_cand = self._get_candidates(max_nframes)
+        id_cand_list = [[] for ii in range(ntraj)]
+        for ii in id_cand:
+            id_cand_list[ii[0]].append(ii[1])
+        return id_cand_list
+
+    def _get_candidates(
+        self,
+        max_nframes: Optional[int] = None,
+    ) -> List[Tuple[int, int]]:
+        """
+        Get candidates. If number of candidates is larger than `max_nframes`,
+        then select `max_nframes` frames with the largest `max_devi_f` from
+        the candidates.
+
+        Parameters
+        ----------
+        max_nframes
+            The maximal number of frames of candidates.
+
+        Returns
+        -------
+        cand_frames   List[Tuple[int,int]]
+            Candidate frames. A list of tuples: [(traj_idx, frame_idx), ...]
+        """
+        self.traj_cand_picked = []
+        for tidx, tt in enumerate(self.traj_cand):
+            for ff in tt:
+                self.traj_cand_picked.append((tidx, ff))
+        if max_nframes is not None and max_nframes < len(self.traj_cand_picked):
+            # select by maximum
+            max_devi_f = self.model_devi.get(DeviManager.MAX_DEVI_F) # type: ignore
+            ret = sorted(self.traj_cand_picked,
+                         key=lambda x: max_devi_f[x[0]][x[1]],
+                         reverse=True)
+            ret = ret[:max_nframes]
+        else:
+            ret = self.traj_cand_picked
+        return ret

--- a/dpgen2/exploration/report/report_trust_levels_max.py
+++ b/dpgen2/exploration/report/report_trust_levels_max.py
@@ -19,11 +19,12 @@ from ..deviation import (
 from . import (
     ExplorationReport,
 )
-from .report_trust_levels_base import ExplorationReportTrustLevels
+from .report_trust_levels_base import (
+    ExplorationReportTrustLevels,
+)
 
 
 class ExplorationReportTrustLevelsMax(ExplorationReportTrustLevels):
-
     def converged(
         self,
         reports: Optional[List[ExplorationReport]] = None,
@@ -41,7 +42,6 @@ class ExplorationReportTrustLevelsMax(ExplorationReportTrustLevels):
             If the exploration is converged.
         """
         return self.accurate_ratio() >= self.conv_accuracy
-
 
     def get_candidate_ids(
         self,
@@ -79,10 +79,12 @@ class ExplorationReportTrustLevelsMax(ExplorationReportTrustLevels):
                 self.traj_cand_picked.append((tidx, ff))
         if max_nframes is not None and max_nframes < len(self.traj_cand_picked):
             # select by maximum
-            max_devi_f = self.model_devi.get(DeviManager.MAX_DEVI_F) # type: ignore
-            ret = sorted(self.traj_cand_picked,
-                         key=lambda x: max_devi_f[x[0]][x[1]],
-                         reverse=True)
+            max_devi_f = self.model_devi.get(DeviManager.MAX_DEVI_F)  # type: ignore
+            ret = sorted(
+                self.traj_cand_picked,
+                key=lambda x: max_devi_f[x[0]][x[1]],
+                reverse=True,
+            )
             ret = ret[:max_nframes]
         else:
             ret = self.traj_cand_picked

--- a/dpgen2/exploration/report/report_trust_levels_random.py
+++ b/dpgen2/exploration/report/report_trust_levels_random.py
@@ -1,0 +1,85 @@
+import random
+from typing import (
+    List,
+    Optional,
+    Tuple,
+)
+
+import numpy as np
+from dargs import (
+    Argument,
+)
+from dflow.python import (
+    FatalError,
+)
+
+from ..deviation import (
+    DeviManager,
+)
+from . import (
+    ExplorationReport,
+)
+from .report_trust_levels_base import ExplorationReportTrustLevels
+
+
+class ExplorationReportTrustLevelsRandom(ExplorationReportTrustLevels):
+
+    def converged(
+        self,
+        reports: Optional[List[ExplorationReport]] = None,
+    ) -> bool:
+        r"""Check if the exploration is converged.
+
+        Parameters
+        ----------
+        reports
+            Historical reports
+
+        Returns
+        -------
+        converged  bool
+            If the exploration is converged.
+        """
+        return self.accurate_ratio() >= self.conv_accuracy
+
+
+    def get_candidate_ids(
+        self,
+        max_nframes: Optional[int] = None,
+    ) -> List[List[int]]:
+        ntraj = len(self.traj_nframes)
+        id_cand = self._get_candidates(max_nframes)
+        id_cand_list = [[] for ii in range(ntraj)]
+        for ii in id_cand:
+            id_cand_list[ii[0]].append(ii[1])
+        return id_cand_list
+
+    def _get_candidates(
+        self,
+        max_nframes: Optional[int] = None,
+    ) -> List[Tuple[int, int]]:
+        """
+        Get candidates. If number of candidates is larger than `max_nframes`,
+        then randomly pick `max_nframes` frames from the candidates.
+
+        Parameters
+        ----------
+        max_nframes
+            The maximal number of frames of candidates.
+
+        Returns
+        -------
+        cand_frames   List[Tuple[int,int]]
+            Candidate frames. A list of tuples: [(traj_idx, frame_idx), ...]
+        """
+        self.traj_cand_picked = []
+        for tidx, tt in enumerate(self.traj_cand):
+            for ff in tt:
+                self.traj_cand_picked.append((tidx, ff))
+        if max_nframes is not None and max_nframes < len(self.traj_cand_picked):
+            # random selection
+            random.shuffle(self.traj_cand_picked)
+            ret = sorted(self.traj_cand_picked[:max_nframes])
+        else:
+            ret = self.traj_cand_picked
+        return ret

--- a/dpgen2/exploration/report/report_trust_levels_random.py
+++ b/dpgen2/exploration/report/report_trust_levels_random.py
@@ -19,11 +19,12 @@ from ..deviation import (
 from . import (
     ExplorationReport,
 )
-from .report_trust_levels_base import ExplorationReportTrustLevels
+from .report_trust_levels_base import (
+    ExplorationReportTrustLevels,
+)
 
 
 class ExplorationReportTrustLevelsRandom(ExplorationReportTrustLevels):
-
     def converged(
         self,
         reports: Optional[List[ExplorationReport]] = None,
@@ -41,7 +42,6 @@ class ExplorationReportTrustLevelsRandom(ExplorationReportTrustLevels):
             If the exploration is converged.
         """
         return self.accurate_ratio() >= self.conv_accuracy
-
 
     def get_candidate_ids(
         self,

--- a/tests/entrypoint/test_submit.py
+++ b/tests/entrypoint/test_submit.py
@@ -24,7 +24,7 @@ from dpgen2.exploration.render import (
 )
 from dpgen2.exploration.report import (
     ExplorationReport,
-    ExplorationReportTrustLevels,
+    ExplorationReportTrustLevelsRandom,
 )
 from dpgen2.exploration.scheduler import (
     ConvergenceCheckStageScheduler,
@@ -138,7 +138,7 @@ class TestSubmit(unittest.TestCase):
     def test_copy_scheduler(self):
         scheduler = ExplorationScheduler()
         scheduler_new = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -154,7 +154,7 @@ class TestSubmit(unittest.TestCase):
         )
         scheduler_new.add_stage_scheduler(stage_scheduler)
 
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -233,7 +233,7 @@ class TestSubmit(unittest.TestCase):
     def test_copy_scheduler_complete(self):
         scheduler = ExplorationScheduler()
         scheduler_new = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -250,7 +250,7 @@ class TestSubmit(unittest.TestCase):
         )
         scheduler_new.add_stage_scheduler(stage_scheduler)
 
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(

--- a/tests/exploration/test_conf_selector_frame.py
+++ b/tests/exploration/test_conf_selector_frame.py
@@ -16,7 +16,7 @@ from dpgen2.exploration.render import (
     TrajRenderLammps,
 )
 from dpgen2.exploration.report import (
-    ExplorationReportTrustLevels,
+    ExplorationReportTrustLevelsRandom,
 )
 from dpgen2.exploration.selector import (
     ConfSelectorFrames,
@@ -90,7 +90,7 @@ class TestConfSelectorFrames(unittest.TestCase):
                 shutil.rmtree(ii)
 
     def test_f_0(self):
-        report = ExplorationReportTrustLevels(0.1, 0.5, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.5, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         conf_selector = ConfSelectorFrames(
             traj_render,
@@ -118,7 +118,7 @@ class TestConfSelectorFrames(unittest.TestCase):
         self.assertAlmostEqual(report.failed_ratio(), 0.0)
 
     def test_f_1(self):
-        report = ExplorationReportTrustLevels(0.25, 0.35, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.25, 0.35, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         conf_selector = ConfSelectorFrames(traj_render, report)
         confs, report = conf_selector.select(
@@ -139,7 +139,7 @@ class TestConfSelectorFrames(unittest.TestCase):
         self.assertAlmostEqual(report.failed_ratio(), 1.0 / 3.0)
 
     def test_fv_0(self):
-        report = ExplorationReportTrustLevels(0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         conf_selector = ConfSelectorFrames(
             traj_render,
@@ -166,7 +166,7 @@ class TestConfSelectorFrames(unittest.TestCase):
         self.assertAlmostEqual(report.failed_ratio(), 2.0 / 3.0)
 
     def test_fv_1(self):
-        report = ExplorationReportTrustLevels(0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         conf_selector = ConfSelectorFrames(
             traj_render,

--- a/tests/exploration/test_conf_selector_frame.py
+++ b/tests/exploration/test_conf_selector_frame.py
@@ -139,7 +139,9 @@ class TestConfSelectorFrames(unittest.TestCase):
         self.assertAlmostEqual(report.failed_ratio(), 1.0 / 3.0)
 
     def test_fv_0(self):
-        report = ExplorationReportTrustLevelsRandom(0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(
+            0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9
+        )
         traj_render = TrajRenderLammps()
         conf_selector = ConfSelectorFrames(
             traj_render,
@@ -166,7 +168,9 @@ class TestConfSelectorFrames(unittest.TestCase):
         self.assertAlmostEqual(report.failed_ratio(), 2.0 / 3.0)
 
     def test_fv_1(self):
-        report = ExplorationReportTrustLevelsRandom(0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(
+            0.25, 0.35, 0.05, 0.15, conv_accuracy=0.9
+        )
         traj_render = TrajRenderLammps()
         conf_selector = ConfSelectorFrames(
             traj_render,

--- a/tests/exploration/test_exploration_scheduler.py
+++ b/tests/exploration/test_exploration_scheduler.py
@@ -30,8 +30,7 @@ from dpgen2.exploration.render import (
     TrajRenderLammps,
 )
 from dpgen2.exploration.report import (
-    ExplorationReport,
-    ExplorationReportTrustLevels,
+    ExplorationReportTrustLevelsRandom,
 )
 from dpgen2.exploration.scheduler import (
     ConvergenceCheckStageScheduler,
@@ -60,7 +59,7 @@ from mocked_ops import (
 
 class TestConvergenceCheckStageScheduler(unittest.TestCase):
     def test_success(self):
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         self.selector = ConfSelectorFrames(traj_render, report)
         self.scheduler = ConvergenceCheckStageScheduler(
@@ -86,7 +85,7 @@ class TestConvergenceCheckStageScheduler(unittest.TestCase):
         self.assertTrue(sel is None)
 
     def test_step1(self):
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         self.selector = ConfSelectorFrames(traj_render, report)
         self.scheduler = ConvergenceCheckStageScheduler(
@@ -130,7 +129,7 @@ class TestConvergenceCheckStageScheduler(unittest.TestCase):
         # self.assertTrue(sel.report.level_v_hi is None)
 
     def test_max_numb_iter(self):
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         self.selector = ConfSelectorFrames(traj_render, report)
         self.scheduler = ConvergenceCheckStageScheduler(
@@ -171,7 +170,7 @@ class TestConvergenceCheckStageScheduler(unittest.TestCase):
 class TestExplorationScheduler(unittest.TestCase):
     def test_success(self):
         scheduler = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -180,7 +179,7 @@ class TestExplorationScheduler(unittest.TestCase):
             max_numb_iter=2,
         )
         scheduler.add_stage_scheduler(stage_scheduler)
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -259,7 +258,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_print_scheduler(self):
         scheduler = ExplorationScheduler()
-        report_0 = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report_0 = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render_0 = TrajRenderLammps()
         selector_0 = ConfSelectorFrames(traj_render_0, report_0)
         stage_scheduler_0 = ConvergenceCheckStageScheduler(
@@ -268,7 +267,7 @@ class TestExplorationScheduler(unittest.TestCase):
             max_numb_iter=2,
         )
         scheduler.add_stage_scheduler(stage_scheduler_0)
-        report_1 = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report_1 = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render_1 = TrajRenderLammps()
         selector_1 = ConfSelectorFrames(traj_render_1, report_1)
         stage_scheduler_1 = ConvergenceCheckStageScheduler(
@@ -280,17 +279,17 @@ class TestExplorationScheduler(unittest.TestCase):
 
         model_devi = DeviManagerStd()
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([0.08, 0.05]))
-        tar_report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        tar_report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         tar_report.record(model_devi)
 
         model_devi.clear()
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([0.3, 0.9]))
-        foo_report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        foo_report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         foo_report.record(model_devi)
 
         model_devi.clear()
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([0.1, 0.1]))
-        bar_report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        bar_report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         bar_report.record(model_devi)
 
         expected_output = [
@@ -322,7 +321,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_print_scheduler_last_iteration(self):
         scheduler = ExplorationScheduler()
-        report_0 = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report_0 = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render_0 = TrajRenderLammps()
         selector_0 = ConfSelectorFrames(traj_render_0, report_0)
         stage_scheduler_0 = ConvergenceCheckStageScheduler(
@@ -331,7 +330,7 @@ class TestExplorationScheduler(unittest.TestCase):
             max_numb_iter=2,
         )
         scheduler.add_stage_scheduler(stage_scheduler_0)
-        report_1 = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report_1 = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render_1 = TrajRenderLammps()
         selector_1 = ConfSelectorFrames(traj_render_1, report_1)
         stage_scheduler_1 = ConvergenceCheckStageScheduler(
@@ -343,17 +342,17 @@ class TestExplorationScheduler(unittest.TestCase):
 
         model_devi = DeviManagerStd()
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([0.08, 0.05]))
-        tar_report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        tar_report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         tar_report.record(model_devi)
 
         model_devi.clear()
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([0.3, 0.9]))
-        foo_report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        foo_report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         foo_report.record(model_devi)
 
         model_devi.clear()
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([0.1, 0.1]))
-        bar_report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        bar_report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         bar_report.record(model_devi)
 
         expected_output = [
@@ -386,7 +385,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_success_and_ratios(self):
         scheduler = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -395,7 +394,7 @@ class TestExplorationScheduler(unittest.TestCase):
             max_numb_iter=4,
         )
         scheduler.add_stage_scheduler(stage_scheduler)
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -480,7 +479,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_success_two_stages(self):
         scheduler = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -490,7 +489,7 @@ class TestExplorationScheduler(unittest.TestCase):
         )
         scheduler.add_stage_scheduler(stage_scheduler)
 
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -581,7 +580,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_continue_adding_success(self):
         scheduler = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -621,7 +620,7 @@ class TestExplorationScheduler(unittest.TestCase):
         self.assertTrue(scheduler.stage_schedulers[0].complete())
         self.assertTrue(scheduler.complete())
 
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -683,7 +682,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_failed_stage0(self):
         scheduler = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -692,7 +691,7 @@ class TestExplorationScheduler(unittest.TestCase):
             max_numb_iter=2,
         )
         scheduler.add_stage_scheduler(stage_scheduler)
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -743,7 +742,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_failed_stage0_not_fatal(self):
         scheduler = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -753,7 +752,7 @@ class TestExplorationScheduler(unittest.TestCase):
             fatal_at_max=False,
         )
         scheduler.add_stage_scheduler(stage_scheduler)
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -820,7 +819,7 @@ class TestExplorationScheduler(unittest.TestCase):
 
     def test_failed_stage1(self):
         scheduler = ExplorationScheduler()
-        report = ExplorationReportTrustLevels(0.1, 0.3, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.1, 0.3, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(
@@ -829,7 +828,7 @@ class TestExplorationScheduler(unittest.TestCase):
             max_numb_iter=2,
         )
         scheduler.add_stage_scheduler(stage_scheduler)
-        report = ExplorationReportTrustLevels(0.2, 0.4, conv_accuracy=0.9)
+        report = ExplorationReportTrustLevelsRandom(0.2, 0.4, conv_accuracy=0.9)
         traj_render = TrajRenderLammps()
         selector = ConfSelectorFrames(traj_render, report)
         stage_scheduler = ConvergenceCheckStageScheduler(

--- a/tests/exploration/test_report_adaptive_lower.py
+++ b/tests/exploration/test_report_adaptive_lower.py
@@ -22,7 +22,7 @@ from dpgen2.exploration.report import (
 )
 
 
-class TestTrajsExplorationResport(unittest.TestCase):
+class TestTrajsExplorationReport(unittest.TestCase):
     def test_fv(self):
         model_devi = DeviManagerStd()
         model_devi.add(

--- a/tests/exploration/test_report_trust_levels.py
+++ b/tests/exploration/test_report_trust_levels.py
@@ -18,31 +18,31 @@ from dpgen2.exploration.deviation import (
     DeviManagerStd,
 )
 from dpgen2.exploration.report import (
-    ExplorationReportTrustLevelsRandom,
     ExplorationReportTrustLevelsMax,
+    ExplorationReportTrustLevelsRandom,
 )
-
-from dpgen2.exploration.report.report_trust_levels_base import ExplorationReportTrustLevels
+from dpgen2.exploration.report.report_trust_levels_base import (
+    ExplorationReportTrustLevels,
+)
 
 
 class TestTrajsExplorationReport(unittest.TestCase):
     def test_exploration_report_trust_levels(self):
-        # class ExplorationReportTrustLevelsRandom and 
-        # ExplorationReportTrustLevelsMax have the same 
+        # class ExplorationReportTrustLevelsRandom and
+        # ExplorationReportTrustLevelsMax have the same
         # behavior in frames selection when traj_cand <= max_nframes
         self.fv_selection_test(ExplorationReportTrustLevelsRandom)
         self.fv_selection_test(ExplorationReportTrustLevelsMax)
-        
+
         self.f_selection_test(ExplorationReportTrustLevelsRandom)
         self.f_selection_test(ExplorationReportTrustLevelsMax)
-        
+
         self.f_max_selection_test(ExplorationReportTrustLevelsRandom)
         self.f_max_selection_test(ExplorationReportTrustLevelsMax)
-        
+
         self.args_test(ExplorationReportTrustLevelsRandom)
         self.args_test(ExplorationReportTrustLevelsMax)
-        
-        
+
     def fv_selection_test(self, exploration_report: ExplorationReportTrustLevels):
         model_devi = DeviManagerStd()
         model_devi.add(
@@ -189,7 +189,7 @@ class TestTrajsExplorationReport(unittest.TestCase):
         self.assertTrue(data["level_v_hi"] is None)
         self.assertAlmostEqual(data["conv_accuracy"], 0.9)
         exploration_report(*data)
-    
+
     def test_max_selection(self):
         model_devi = DeviManagerStd()
         model_devi.add(
@@ -213,8 +213,7 @@ class TestTrajsExplorationReport(unittest.TestCase):
                 self.assertTrue(jj in expected_cand[ii])
                 npicked += 1
         self.assertEqual(npicked, 2)
-    
-    
+
     def test_random_selection_convergence(self):
         # case 1
         model_devi = DeviManagerStd()
@@ -253,7 +252,7 @@ class TestTrajsExplorationReport(unittest.TestCase):
         ter = ExplorationReportTrustLevelsRandom(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
         ter.record(model_devi)
         self.assertTrue(ter.converged())
-        
+
         # case 3
         model_devi = DeviManagerStd()
         model_devi.add(

--- a/tests/exploration/test_report_trust_levels.py
+++ b/tests/exploration/test_report_trust_levels.py
@@ -18,12 +18,32 @@ from dpgen2.exploration.deviation import (
     DeviManagerStd,
 )
 from dpgen2.exploration.report import (
-    ExplorationReportTrustLevels,
+    ExplorationReportTrustLevelsRandom,
+    ExplorationReportTrustLevelsMax,
 )
 
+from dpgen2.exploration.report.report_trust_levels_base import ExplorationReportTrustLevels
 
-class TestTrajsExplorationResport(unittest.TestCase):
-    def test_fv(self):
+
+class TestTrajsExplorationReport(unittest.TestCase):
+    def test_exploration_report_trust_levels(self):
+        # class ExplorationReportTrustLevelsRandom and 
+        # ExplorationReportTrustLevelsMax have the same 
+        # behavior in frames selection when traj_cand <= max_nframes
+        self.fv_selection_test(ExplorationReportTrustLevelsRandom)
+        self.fv_selection_test(ExplorationReportTrustLevelsMax)
+        
+        self.f_selection_test(ExplorationReportTrustLevelsRandom)
+        self.f_selection_test(ExplorationReportTrustLevelsMax)
+        
+        self.f_max_selection_test(ExplorationReportTrustLevelsRandom)
+        self.f_max_selection_test(ExplorationReportTrustLevelsMax)
+        
+        self.args_test(ExplorationReportTrustLevelsRandom)
+        self.args_test(ExplorationReportTrustLevelsMax)
+        
+        
+    def fv_selection_test(self, exploration_report: ExplorationReportTrustLevels):
         model_devi = DeviManagerStd()
         model_devi.add(
             DeviManager.MAX_DEVI_F,
@@ -56,9 +76,8 @@ class TestTrajsExplorationResport(unittest.TestCase):
         expected_fail = [set(ii) for ii in expected_fail]
         all_cand_sel = [(0, 6), (0, 5), (1, 8), (1, 6), (1, 0), (1, 5)]
 
-        ter = ExplorationReportTrustLevels(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.9)
+        ter = exploration_report(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.9)
         ter.record(model_devi)
-        self.assertFalse(ter.converged())
         self.assertEqual(ter.traj_cand, expected_cand)
         self.assertEqual(ter.traj_accu, expected_accu)
         self.assertEqual(ter.traj_fail, expected_fail)
@@ -75,7 +94,7 @@ class TestTrajsExplorationResport(unittest.TestCase):
         self.assertEqual(ter.accurate_ratio(), 2.0 / 18.0)
         self.assertEqual(ter.failed_ratio(), 10.0 / 18.0)
 
-    def test_f(self):
+    def f_selection_test(self, exploration_report: ExplorationReportTrustLevels):
         model_devi = DeviManagerStd()
         model_devi.add(
             DeviManager.MAX_DEVI_F,
@@ -100,9 +119,8 @@ class TestTrajsExplorationResport(unittest.TestCase):
         expected_fail = [set(ii) for ii in expected_fail]
         all_cand_sel = [(0, 4), (0, 7), (0, 6), (1, 6), (1, 0), (1, 8)]
 
-        ter = ExplorationReportTrustLevels(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
+        ter = exploration_report(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
         ter.record(model_devi)
-        self.assertTrue(ter.converged())
         self.assertEqual(ter.traj_cand, expected_cand)
         self.assertEqual(ter.traj_accu, expected_accu)
         self.assertEqual(ter.traj_fail, expected_fail)
@@ -116,7 +134,7 @@ class TestTrajsExplorationResport(unittest.TestCase):
                 npicked += 1
         self.assertEqual(npicked, 2)
 
-    def test_f_max(self):
+    def f_max_selection_test(self, exploration_report: ExplorationReportTrustLevels):
         model_devi = DeviManagerStd()
         model_devi.add(
             DeviManager.MAX_DEVI_F,
@@ -141,9 +159,8 @@ class TestTrajsExplorationResport(unittest.TestCase):
         expected_fail = [set(ii) for ii in expected_fail]
         all_cand_sel = [(0, 4), (0, 7), (0, 6), (1, 6), (1, 0), (1, 8)]
 
-        ter = ExplorationReportTrustLevels(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
+        ter = exploration_report(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
         ter.record(model_devi)
-        self.assertTrue(ter.converged())
         self.assertEqual(ter.traj_cand, expected_cand)
         self.assertEqual(ter.traj_accu, expected_accu)
         self.assertEqual(ter.traj_fail, expected_fail)
@@ -157,18 +174,111 @@ class TestTrajsExplorationResport(unittest.TestCase):
                 npicked += 1
         self.assertEqual(npicked, 6)
 
-    def test_args(self):
+    def args_test(self, exploration_report: ExplorationReportTrustLevels):
         input_dict = {
             "level_f_lo": 0.5,
             "level_f_hi": 1.0,
             "conv_accuracy": 0.9,
         }
 
-        base = Argument("base", dict, ExplorationReportTrustLevels.args())
+        base = Argument("base", dict, exploration_report.args())
         data = base.normalize_value(input_dict)
         self.assertAlmostEqual(data["level_f_lo"], 0.5)
         self.assertAlmostEqual(data["level_f_hi"], 1.0)
         self.assertTrue(data["level_v_lo"] is None)
         self.assertTrue(data["level_v_hi"] is None)
         self.assertAlmostEqual(data["conv_accuracy"], 0.9)
-        ExplorationReportTrustLevels(*data)
+        exploration_report(*data)
+    
+    def test_max_selection(self):
+        model_devi = DeviManagerStd()
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.90, 0.10, 0.91, 0.11, 0.50, 0.12, 0.51, 0.52, 0.92]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.40, 0.20, 0.80, 0.81, 0.82, 0.21, 0.41, 0.22, 0.42]),
+        )
+
+        ter = ExplorationReportTrustLevelsMax(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
+        ter.record(model_devi)
+
+        expected_cand = [(7, 6), ()]
+        picked = ter.get_candidate_ids(2)
+        npicked = 0
+        self.assertEqual(len(picked), 2)
+        for ii in range(2):
+            for jj in picked[ii]:
+                self.assertTrue(jj in expected_cand[ii])
+                npicked += 1
+        self.assertEqual(npicked, 2)
+    
+    
+    def test_random_selection_convergence(self):
+        # case 1
+        model_devi = DeviManagerStd()
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.90, 0.10, 0.91, 0.11, 0.50, 0.12, 0.51, 0.52, 0.92]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.40, 0.20, 0.80, 0.81, 0.82, 0.21, 0.41, 0.22, 0.42]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_V,
+            np.array([0.40, 0.20, 0.21, 0.80, 0.81, 0.41, 0.22, 0.82, 0.42]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_V,
+            np.array([0.50, 0.90, 0.91, 0.92, 0.51, 0.52, 0.10, 0.11, 0.12]),
+        )
+
+        ter = ExplorationReportTrustLevelsRandom(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.9)
+        ter.record(model_devi)
+        self.assertFalse(ter.converged())
+
+        # case 2
+        model_devi = DeviManagerStd()
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.90, 0.10, 0.91, 0.11, 0.50, 0.12, 0.51, 0.52, 0.92]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.40, 0.20, 0.80, 0.81, 0.82, 0.21, 0.41, 0.22, 0.42]),
+        )
+
+        ter = ExplorationReportTrustLevelsRandom(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
+        ter.record(model_devi)
+        self.assertTrue(ter.converged())
+        
+        # case 3
+        model_devi = DeviManagerStd()
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.90, 0.10, 0.91, 0.11, 0.50, 0.12, 0.51, 0.52, 0.92]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.40, 0.20, 0.80, 0.81, 0.82, 0.21, 0.41, 0.22, 0.42]),
+        )
+
+        id_f_accu = [[3, 5, 1], [1, 7, 5]]
+        id_f_cand = [[4, 7, 6], [8, 6, 0]]
+        id_f_fail = [[2, 0, 8], [4, 2, 3]]
+        # id_v_accu = [None, None]
+        # id_v_cand = [None, None]
+        # id_v_fail = [None, None]
+        expected_accu = id_f_accu
+        expected_cand = id_f_cand
+        expected_fail = id_f_fail
+        expected_accu = [set(ii) for ii in expected_accu]
+        expected_cand = [set(ii) for ii in expected_cand]
+        expected_fail = [set(ii) for ii in expected_fail]
+        all_cand_sel = [(0, 4), (0, 7), (0, 6), (1, 6), (1, 0), (1, 8)]
+
+        ter = ExplorationReportTrustLevelsRandom(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.2)
+        ter.record(model_devi)
+        self.assertTrue(ter.converged())


### PR DESCRIPTION
If the number of candidates is larger than `max_nframes`, then select `max_nframes` frames with the largest `max_devi_f` from the candidates.