### PR TITLE
Fix bugs related to the customized lmp task group submission

### DIFF
--- a/dpgen2/exploration/task/customized_lmp_template_task_group.py
+++ b/dpgen2/exploration/task/customized_lmp_template_task_group.py
@@ -10,7 +10,9 @@ from typing import (
     Optional,
     Union,
 )
-
+from dflow.python import (
+    FatalError,
+)
 from dpgen2.constants import (
     lmp_conf_name,
     lmp_input_name,
@@ -173,11 +175,11 @@ class CustomizedLmpTemplateTaskGroup(ConfSamplingTaskGroup):
                     Path(ff).write_text(cc)
                 # run all customized shell commands
                 for ss in self.custom_shell_commands:
-                    # run shell command with os.system
-                    ret = os.system(ss)
+                    # run shell command with dpgen2.utils.run_command
+                    ret, out, err = run_command(ss, shell=True)
                     if ret != 0:
-                        raise RuntimeError(
-                            f"execution of {ss} returns a non-zero value {ret}"
+                        raise FatalError(
+                            f"customized shell command {ss} failed with return code {ret}\n", "out msg", out, "\n", "err msg", err, "\n"
                         )
                 # loop over all pattern matched result dirs
                 for ff in [
@@ -191,7 +193,7 @@ class CustomizedLmpTemplateTaskGroup(ConfSamplingTaskGroup):
                     # no matched continue
                     if matched_ff is None:
                         logging.info(
-                            "No output dir matches the patter {self.output_dir_pattern} "
+                            f"Dir {ff} does not matches the patter {self.output_dir_pattern} "
                         )
                         continue
                     with set_directory(Path(matched_ff)):

--- a/dpgen2/op/collect_data.py
+++ b/dpgen2/op/collect_data.py
@@ -15,6 +15,7 @@ from dflow.python import (
     OPIO,
     Artifact,
     BigParameter,
+    Parameter,
     OPIOSign,
     Parameter,
 )
@@ -41,7 +42,7 @@ class CollectData(OP):
             {
                 "name": str,
                 "type_map": List[str],
-                "optional_parameter": BigParameter(
+                "optional_parameter": Parameter(
                     dict,
                     default=CollectData.default_optional_parameter,
                 ),

--- a/dpgen2/op/run_dp_train.py
+++ b/dpgen2/op/run_dp_train.py
@@ -22,6 +22,7 @@ from dflow.python import (
     OPIO,
     Artifact,
     BigParameter,
+    Parameter,
     FatalError,
     OPIOSign,
     TransientError,
@@ -60,7 +61,7 @@ class RunDPTrain(OP):
             {
                 "config": dict,
                 "task_name": BigParameter(str),
-                "optional_parameter": BigParameter(
+                "optional_parameter": Parameter(
                     dict,
                     default=RunDPTrain.default_optional_parameter,
                 ),

--- a/dpgen2/op/run_lmp.py
+++ b/dpgen2/op/run_lmp.py
@@ -34,6 +34,7 @@ from dpgen2.constants import (
     lmp_log_name,
     lmp_model_devi_name,
     lmp_traj_name,
+    plm_output_name,
     model_name_match_pattern,
     model_name_pattern,
 )
@@ -117,8 +118,9 @@ class RunLmp(OP):
         task_name = ip["task_name"]
         task_path = ip["task_path"]
         models = ip["models"]
-        input_files = [lmp_conf_name, lmp_input_name]
-        input_files = [(Path(task_path) / ii).resolve() for ii in input_files]
+        # input_files = [lmp_conf_name, lmp_input_name]
+        # input_files = [(Path(task_path) / ii).resolve() for ii in input_files]
+        input_files = [ii.resolve() for ii in Path(task_path).iterdir()]
         model_files = [Path(ii).resolve() for ii in models]
         work_dir = Path(task_name)
 
@@ -150,16 +152,20 @@ class RunLmp(OP):
             ret, out, err = run_command(command, shell=True)
             if ret != 0:
                 raise TransientError(
-                    "lmp failed\n", "out msg", out, "\n", "err msg", err, "\n"
+                    "lmp failed\n", "command was", command, "out msg", out, "\n", "err msg", err, "\n"
                 )
-
-        return OPIO(
-            {
+            
+        ret_dict = {
                 "log": work_dir / lmp_log_name,
                 "traj": work_dir / lmp_traj_name,
                 "model_devi": work_dir / lmp_model_devi_name,
-            }
-        )
+        }
+        plm_output = {'plm_output' : work_dir/plm_output_name} \
+            if (work_dir/plm_output_name).is_file() else {}
+        ret_dict.update(plm_output)
+
+        return OPIO(ret_dict)
+
 
     @staticmethod
     def lmp_args():

--- a/dpgen2/utils/run_command.py
+++ b/dpgen2/utils/run_command.py
@@ -15,7 +15,7 @@ def run_command(
     cmd: Union[str, List[str]],
     shell: bool = False,
 ) -> Tuple[int, str, str]:
-    interactive = False if config["mode"] == "debug" else True
+    interactive = False
     return dflow_run_command(
         cmd, raise_error=False, try_bash=shell, interactive=interactive
     )

--- a/dpgen2/utils/run_command.py
+++ b/dpgen2/utils/run_command.py
@@ -15,7 +15,7 @@ def run_command(
     cmd: Union[str, List[str]],
     shell: bool = False,
 ) -> Tuple[int, str, str]:
-    interactive = False
+    interactive = False if config["mode"] == "debug" else True
     return dflow_run_command(
         cmd, raise_error=False, try_bash=shell, interactive=interactive
     )


### PR DESCRIPTION
1. run customized command with dpgen run_command.
2. fix bug in run_command interface to dflow.utils.run_command: always non-interactive. [reverted!`interactive` means the bashrc file would be sourced, otherwise, not.]
3. optional parameters should be of type `Parameter`, `BigParameter` cannot be indexed. 
4. link plumed input file to lammps task dir. Output plumed if they present. 