### PR TITLE
fix: correct the position of import dpgen2 in tests

### DIFF
--- a/tests/conf/test_alloy_conf.py
+++ b/tests/conf/test_alloy_conf.py
@@ -20,6 +20,8 @@ from dpgen2.conf.alloy_conf import (
     normalize,
 )
 
+# isort: on
+
 
 ofc0 = "\n1 atoms\n2 atom types\n   0.0000000000    2.0000000000 xlo xhi\n   0.0000000000    2.0000000000 ylo yhi\n   0.0000000000    2.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      1    0.0000000000    0.0000000000    0.0000000000\n"
 ofc1 = "\n1 atoms\n2 atom types\n   0.0000000000    3.0000000000 xlo xhi\n   0.0000000000    3.0000000000 ylo yhi\n   0.0000000000    3.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"

--- a/tests/conf/test_alloy_conf.py
+++ b/tests/conf/test_alloy_conf.py
@@ -11,6 +11,8 @@ from pathlib import (
 import dpdata
 import numpy as np
 
+# isort: off
+from .context import dpgen2
 from dpgen2.conf.alloy_conf import (
     AlloyConf,
     AlloyConfGenerator,
@@ -18,9 +20,6 @@ from dpgen2.conf.alloy_conf import (
     normalize,
 )
 
-from .context import (
-    dpgen2,
-)
 
 ofc0 = "\n1 atoms\n2 atom types\n   0.0000000000    2.0000000000 xlo xhi\n   0.0000000000    2.0000000000 ylo yhi\n   0.0000000000    2.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      1    0.0000000000    0.0000000000    0.0000000000\n"
 ofc1 = "\n1 atoms\n2 atom types\n   0.0000000000    3.0000000000 xlo xhi\n   0.0000000000    3.0000000000 ylo yhi\n   0.0000000000    3.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"

--- a/tests/conf/test_file_conf.py
+++ b/tests/conf/test_file_conf.py
@@ -12,13 +12,15 @@ from pathlib import (
 import dpdata
 import numpy as np
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.conf.file_conf import (
     FileConfGenerator,
 )
 
-from .context import (
-    dpgen2,
-)
+# isort: on
 
 pos0 = textwrap.dedent(
     """POSCAR file written by OVITO

--- a/tests/conf/test_unit_cell.py
+++ b/tests/conf/test_unit_cell.py
@@ -8,13 +8,15 @@ from pathlib import (
 
 import numpy as np
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.conf.unit_cells import (
     generate_unit_cell,
 )
 
-from .context import (
-    dpgen2,
-)
+# isort: on
 
 
 class TestGenerateUnitCell(unittest.TestCase):

--- a/tests/entrypoint/test_argparse.py
+++ b/tests/entrypoint/test_argparse.py
@@ -3,11 +3,17 @@ import os
 import shutil
 import unittest
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.entrypoint.main import (
     main_parser,
     parse_args,
     workflow_subcommands,
 )
+
+# isort: off
 
 
 class ParserTest(unittest.TestCase):

--- a/tests/entrypoint/test_submit.py
+++ b/tests/entrypoint/test_submit.py
@@ -12,6 +12,10 @@ from pathlib import (
 import dpdata
 import numpy as np
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.entrypoint.submit import (
     copy_scheduler_plans,
     expand_idx,
@@ -37,11 +41,6 @@ from dpgen2.exploration.task import (
     ExplorationStage,
     ExplorationTaskGroup,
 )
-
-# isort: off
-from .context import (
-    dpgen2,
-)
 from mocked_ops import (
     MockedExplorationReport,
     MockedExplorationTaskGroup,
@@ -51,6 +50,7 @@ from mocked_ops import (
 )
 
 # isort: on
+
 
 ifc0 = """Al1 
 1.0

--- a/tests/entrypoint/test_submit_args.py
+++ b/tests/entrypoint/test_submit_args.py
@@ -12,6 +12,10 @@ from pathlib import (
 import dpdata
 import numpy as np
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.entrypoint.args import (
     normalize,
 )
@@ -23,9 +27,7 @@ from dpgen2.utils import (
     normalize_step_dict,
 )
 
-from .context import (
-    dpgen2,
-)
+# isort: on
 
 
 class TestArgs(unittest.TestCase):

--- a/tests/entrypoint/test_workflow.py
+++ b/tests/entrypoint/test_workflow.py
@@ -10,6 +10,10 @@ from dflow import (
     Workflow,
 )
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.entrypoint.workflow import (
     execute_workflow_subcommand,
 )

--- a/tests/exploration/test_conf_filter.py
+++ b/tests/exploration/test_conf_filter.py
@@ -10,14 +10,16 @@ from mock import (
     patch,
 )
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.exploration.selector import (
     ConfFilter,
     ConfFilters,
 )
 
-from .context import (
-    dpgen2,
-)
+# isort: on
 
 
 class FooFilter(ConfFilter):

--- a/tests/exploration/test_conf_selector_frame.py
+++ b/tests/exploration/test_conf_selector_frame.py
@@ -8,10 +8,11 @@ from pathlib import (
 
 import dpdata
 import numpy as np
-from context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.exploration.render import (
     TrajRenderLammps,
 )
@@ -21,6 +22,8 @@ from dpgen2.exploration.report import (
 from dpgen2.exploration.selector import (
     ConfSelectorFrames,
 )
+
+# isort: on
 
 
 class TestConfSelectorFrames(unittest.TestCase):

--- a/tests/exploration/test_devi_manager.py
+++ b/tests/exploration/test_devi_manager.py
@@ -5,14 +5,17 @@ from pathlib import (
 )
 
 import numpy as np
-from context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.exploration.deviation import (
     DeviManager,
     DeviManagerStd,
 )
+
+# isort: on
 
 
 class TestDeviManagerStd(unittest.TestCase):

--- a/tests/exploration/test_report_adaptive_lower.py
+++ b/tests/exploration/test_report_adaptive_lower.py
@@ -7,13 +7,14 @@ from collections import (
 
 import mock
 import numpy as np
-from context import (
-    dpgen2,
-)
 from dargs import (
     Argument,
 )
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.exploration.deviation import (
     DeviManager,
     DeviManagerStd,
@@ -21,6 +22,8 @@ from dpgen2.exploration.deviation import (
 from dpgen2.exploration.report import (
     ExplorationReportAdaptiveLower,
 )
+
+# isort: on
 
 
 class TestTrajsExplorationReport(unittest.TestCase):

--- a/tests/exploration/test_report_trust_levels.py
+++ b/tests/exploration/test_report_trust_levels.py
@@ -6,13 +6,14 @@ from collections import (
 )
 
 import numpy as np
-from context import (
-    dpgen2,
-)
 from dargs import (
     Argument,
 )
 
+# isort: off
+from context import (
+    dpgen2,
+)
 from dpgen2.exploration.deviation import (
     DeviManager,
     DeviManagerStd,
@@ -24,6 +25,8 @@ from dpgen2.exploration.report import (
 from dpgen2.exploration.report.report_trust_levels_base import (
     ExplorationReportTrustLevels,
 )
+
+# isort: on
 
 
 class TestTrajsExplorationReport(unittest.TestCase):

--- a/tests/fp/test_prep_vasp.py
+++ b/tests/fp/test_prep_vasp.py
@@ -24,6 +24,10 @@ from fake_data_set import (
     fake_system,
 )
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.constants import (
     fp_task_pattern,
 )
@@ -39,9 +43,7 @@ from dpgen2.utils import (
     dump_object_to_file,
 )
 
-from .context import (
-    dpgen2,
-)
+# isort: on
 
 
 class TestPrepVasp(unittest.TestCase):

--- a/tests/fp/test_run_vasp.py
+++ b/tests/fp/test_run_vasp.py
@@ -19,6 +19,10 @@ from mock import (
     patch,
 )
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.constants import (
     fp_default_log_name,
     fp_default_out_data_name,
@@ -33,9 +37,7 @@ from dpgen2.fp.vasp import (
     vasp_pot_name,
 )
 
-from .context import (
-    dpgen2,
-)
+# isort: on
 
 
 class TestRunVasp(unittest.TestCase):

--- a/tests/fp/test_vasp.py
+++ b/tests/fp/test_vasp.py
@@ -12,14 +12,16 @@ from pathlib import (
 import dpdata
 import numpy as np
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.fp.vasp import (
     VaspInputs,
     make_kspacing_kpoints,
 )
 
-from .context import (
-    dpgen2,
-)
+# isort: on
 
 
 class TestVASPInputs(unittest.TestCase):

--- a/tests/op/test_collect_data.py
+++ b/tests/op/test_collect_data.py
@@ -23,10 +23,11 @@ from mock import (
     mock,
     patch,
 )
-from op.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.constants import (
     lmp_conf_name,
     lmp_input_name,
@@ -37,6 +38,8 @@ from dpgen2.constants import (
 from dpgen2.op.collect_data import (
     CollectData,
 )
+
+# isort: on
 
 
 class TestRunLmp(unittest.TestCase):

--- a/tests/op/test_prep_dp_train.py
+++ b/tests/op/test_prep_dp_train.py
@@ -15,10 +15,11 @@ from dflow.python import (
 from mock import (
     mock,
 )
-from op.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.constants import (
     train_script_name,
     train_task_pattern,
@@ -26,6 +27,8 @@ from dpgen2.constants import (
 from dpgen2.op.prep_dp_train import (
     PrepDPTrain,
 )
+
+# isort: on
 
 template_script_se_e2_a = {
     "model": {"descriptor": {"type": "se_e2_a", "seed": 1}, "fitting_net": {"seed": 1}},

--- a/tests/op/test_run_dp_train.py
+++ b/tests/op/test_run_dp_train.py
@@ -23,10 +23,11 @@ from mock import (
     call,
     patch,
 )
-from op.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.constants import (
     train_script_name,
     train_task_pattern,
@@ -35,6 +36,8 @@ from dpgen2.op.run_dp_train import (
     RunDPTrain,
     _get_data_size_of_all_mult_sys,
 )
+
+# isort: on
 
 
 class TestRunDPTrain(unittest.TestCase):

--- a/tests/op/test_run_lmp.py
+++ b/tests/op/test_run_lmp.py
@@ -19,10 +19,11 @@ from mock import (
     mock,
     patch,
 )
-from op.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.constants import (
     lmp_conf_name,
     lmp_input_name,
@@ -38,6 +39,8 @@ from dpgen2.op.run_lmp import (
 from dpgen2.utils import (
     BinaryFileInput,
 )
+
+# isort: on
 
 
 class TestRunLmp(unittest.TestCase):

--- a/tests/utils/test_binary_file_input.py
+++ b/tests/utils/test_binary_file_input.py
@@ -7,9 +7,15 @@ from pathlib import (
 
 import numpy as np
 
+# isort: off
+from .context import (
+    dpgen2,
+)
 from dpgen2.utils import (
     BinaryFileInput,
 )
+
+# isort: on
 
 
 class TestBinaryFileInput(unittest.TestCase):

--- a/tests/utils/test_bohrium_config.py
+++ b/tests/utils/test_bohrium_config.py
@@ -19,13 +19,16 @@ from dflow.config import (
 from dflow.plugins import (
     bohrium,
 )
-from utils.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.utils import (
     bohrium_config_from_dict,
 )
+
+# isort: on
 
 
 @pytest.mark.server(

--- a/tests/utils/test_dflow_config.py
+++ b/tests/utils/test_dflow_config.py
@@ -14,14 +14,17 @@ from dflow.config import (
     config,
     s3_config,
 )
-from utils.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.utils import (
     dflow_config,
     dflow_s3_config,
 )
+
+# isort: on
 
 
 class TestDflowConfig(unittest.TestCase):

--- a/tests/utils/test_dl_dpgen2_arti.py
+++ b/tests/utils/test_dl_dpgen2_arti.py
@@ -12,16 +12,19 @@ import dflow
 import dpdata
 import mock
 import numpy as np
-from utils.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.entrypoint.watch import (
     update_finished_steps,
 )
 from dpgen2.utils.download_dpgen2_artifacts import (
     download_dpgen2_artifacts,
 )
+
+# isort: on
 
 
 class MockedArti:

--- a/tests/utils/test_dl_dpgen2_arti_by_def.py
+++ b/tests/utils/test_dl_dpgen2_arti_by_def.py
@@ -13,10 +13,11 @@ import dflow
 import dpdata
 import mock
 import numpy as np
-from utils.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.utils.download_dpgen2_artifacts import (
     DownloadDefinition,
     _get_all_iterations,
@@ -24,6 +25,8 @@ from dpgen2.utils.download_dpgen2_artifacts import (
     download_dpgen2_artifacts_by_def,
     print_op_download_setting,
 )
+
+# isort: on
 
 
 class MockedArti:

--- a/tests/utils/test_run_command.py
+++ b/tests/utils/test_run_command.py
@@ -7,13 +7,16 @@ from pathlib import (
 )
 
 import numpy as np
-from utils.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.utils.run_command import (
     run_command,
 )
+
+# isort: on
 
 
 class TestRunCommand(unittest.TestCase):

--- a/tests/utils/test_step_config.py
+++ b/tests/utils/test_step_config.py
@@ -17,10 +17,11 @@ import numpy as np
 from dflow.python import (
     OPIO,
 )
-from utils.context import (
+
+# isort: off
+from .context import (
     dpgen2,
 )
-
 from dpgen2.constants import (
     default_image,
 )
@@ -31,6 +32,8 @@ from dpgen2.utils import (
     init_executor,
 )
 from dpgen2.utils import normalize_step_dict as normalize
+
+# isort: on
 
 
 @contextmanager


### PR DESCRIPTION
try to skip isort when the relative order of import is critical