### PR TITLE
Fix run caly model devi

### DIFF
--- a/dpgen2/op/collect_run_caly.py
+++ b/dpgen2/op/collect_run_caly.py
@@ -247,7 +247,7 @@ def get_value_from_inputdat(filename):
                 max_step = int(line.strip().split("#")[0].split("=")[1])
                 continue
             if "VSC" in line:
-                vsc_str = line.strip().split("#")[0].split("=")[1].lower()
+                vsc_str = line.strip().split("#")[0].split("=")[1].lower().strip()
                 if vsc_str.startswith("t"):
                     vsc = True
         return max_step, vsc

--- a/dpgen2/op/collect_run_caly.py
+++ b/dpgen2/op/collect_run_caly.py
@@ -69,6 +69,7 @@ class CollRunCaly(OP):
                 "opt_results_dir": Artifact(
                     type=Path, optional=True
                 ),  # dir contains POSCAR* CONTCAR* OUTCAR*
+                "qhull_input": Artifact(type=Path, optional=True),  # for vsc
             }
         )
 
@@ -82,6 +83,7 @@ class CollRunCaly(OP):
                 "input_file": Artifact(Path),  # input.dat
                 "results": Artifact(Path),  # calypso generated results
                 "step": Artifact(Path),  # step
+                "qhull_input": Artifact(Path),
             }
         )
 
@@ -104,6 +106,7 @@ class CollRunCaly(OP):
             - `step`: (`Path`) The step file from last calypso run
             - `results`: (`Path`) The results dir from last calypso run
             - `opt_results_dir`: (`Path`) The results dir contains POSCAR* CONTCAR* OUTCAR* from last calypso run
+            - `qhull_input`: (`Path`) qhull input file `test_qconvex.in`
 
         Returns
         -------
@@ -115,6 +118,7 @@ class CollRunCaly(OP):
             - `input_file`: (`Path`) The input file of the task (input.dat).
             - `step`: (`Path`) The step file.
             - `results`: (`Path`) The results dir.
+            - `qhull_input`: (`Path`) qhull input file.
 
         Raises
         ------
@@ -129,7 +133,7 @@ class CollRunCaly(OP):
         # input.dat
         _input_file = ip["input_file"]
         input_file = _input_file.resolve()
-        max_step = get_max_step(input_file)
+        max_step, vsc = get_value_from_inputdat(input_file)
         # work_dir name: calypso_task.idx
         work_dir = Path(ip["task_name"])
 
@@ -142,10 +146,15 @@ class CollRunCaly(OP):
             if ip["opt_results_dir"] is not None
             else ip["opt_results_dir"]
         )
+        qhull_input = (
+            ip["qhull_input"].resolve()
+            if ip["qhull_input"] is not None
+            else ip["qhull_input"]
+        )
 
         with set_directory(work_dir):
             # prep files/dirs from last calypso run
-            prep_last_calypso_file(step, results, opt_results_dir)
+            prep_last_calypso_file(step, results, opt_results_dir, qhull_input, vsc)
             # copy input.dat
             Path(input_file.name).symlink_to(input_file)
             # run calypso
@@ -177,21 +186,19 @@ class CollRunCaly(OP):
 
             step = Path("step").read_text().strip()
             finished = "true" if int(cnt_num) == int(max_step) else "false"
-            # poscar_dir = "poscar_dir_none" if not finished else poscar_dir
-            # fake_traj = Path("traj_results_dir")
-            # fake_traj.mkdir(parents=True, exist_ok=True)
+
+            if not Path("test_qconvex.in").exists():
+                Path("test_qconvex.in").write_text("")
 
         ret_dict = {
             "task_name": str(work_dir),
             "finished": finished,
             "poscar_dir": work_dir.joinpath(poscar_dir),
-            # "input_file": ip["input_file"],
             "input_file": _input_file,
             "step": work_dir.joinpath("step"),
             "results": work_dir.joinpath("results"),
-            # "fake_traj_results_dir": work_dir.joinpath(fake_traj),
+            "qhull_input": work_dir.joinpath("test_qconvex.in"),
         }
-
         return OPIO(ret_dict)
 
     @staticmethod
@@ -219,19 +226,28 @@ class CollRunCaly(OP):
 config_args = CollRunCaly.calypso_args
 
 
-def prep_last_calypso_file(step, results, opt_results_dir):
+def prep_last_calypso_file(step, results, opt_results_dir, qhull_input, vsc):
     if step is not None and results is not None or opt_results_dir is not None:
         Path(step.name).symlink_to(step)
         Path(results.name).symlink_to(results)
         for file_name in opt_results_dir.iterdir():
             Path(file_name.name).symlink_to(file_name)
 
+    if vsc and qhull_input is not None:
+        Path(qhull_input.name).symlink_to(qhull_input)
 
-def get_max_step(filename):
+
+def get_value_from_inputdat(filename):
+    max_step = 0
+    vsc = False
     with open(filename, "r") as f:
         lines = f.readlines()
         for line in lines:
             if "MaxStep" in line:
                 max_step = int(line.strip().split("#")[0].split("=")[1])
-                return max_step
-        raise ValueError(f"Key 'MaxStep' missed in {str(filename)}")
+                continue
+            if "VSC" in line:
+                vsc_str = line.strip().split("#")[0].split("=")[1].lower()
+                if vsc_str.startswith("t"):
+                    vsc = True
+        return max_step, vsc

--- a/dpgen2/superop/caly_evo_step.py
+++ b/dpgen2/superop/caly_evo_step.py
@@ -73,6 +73,7 @@ class CalyEvoStep(Steps):
             "results": InputArtifact(optional=True),
             "step": InputArtifact(optional=True),
             "opt_results_dir": InputArtifact(optional=True),
+            "qhull_input": InputArtifact(optional=True),
         }
         self._output_parameters = {
             # "task_name": OutputParameter(),
@@ -177,6 +178,7 @@ def _caly_evo_step(
             "step": caly_evo_step_steps.inputs.artifacts["step"],
             "results": caly_evo_step_steps.inputs.artifacts["results"],
             "opt_results_dir": caly_evo_step_steps.inputs.artifacts["opt_results_dir"],
+            "qhull_input": caly_evo_step_steps.inputs.artifacts["qhull_input"],
         },
         key="%s--collect-run-calypso-%s-%s"
         % (
@@ -245,13 +247,14 @@ def _caly_evo_step(
             ],  # input.dat
             "results": collect_run_calypso.outputs.artifacts["results"],
             "step": collect_run_calypso.outputs.artifacts["step"],
+            "qhull_input": collect_run_calypso.outputs.artifacts["qhull_input"],
             "opt_results_dir": prep_run_dp_optim.outputs.artifacts["optim_results_dir"],
             "caly_run_opt_file": prep_run_dp_optim.outputs.artifacts[
                 "caly_run_opt_file"
-            ],  # input.dat
+            ],
             "caly_check_opt_file": prep_run_dp_optim.outputs.artifacts[
                 "caly_check_opt_file"
-            ],  # input.dat
+            ],
         },
         when="%s == false" % (collect_run_calypso.outputs.parameters["finished"]),
     )

--- a/dpgen2/superop/prep_run_calypso.py
+++ b/dpgen2/superop/prep_run_calypso.py
@@ -213,6 +213,7 @@ def _prep_run_caly(
             "results": temp_value,
             "step": temp_value,
             "opt_results_dir": temp_value,
+            "qhull_input": temp_value,
         },
         key=step_keys["caly-evo-step-{{item}}"],
         with_sequence=argo_sequence(

--- a/tests/mocked_ops.py
+++ b/tests/mocked_ops.py
@@ -1157,7 +1157,7 @@ ITEM: ATOMS id type x y z fx fy fz
         return OPIO(
             {
                 "task_name": str(work_dir),
-                "traj": work_dir / dump_file_name,
-                "model_devi": work_dir / model_devi_file_name,
+                "traj": [work_dir / dump_file_name],
+                "model_devi": [work_dir / model_devi_file_name],
             }
         )

--- a/tests/mocked_ops.py
+++ b/tests/mocked_ops.py
@@ -969,6 +969,11 @@ class MockedCollRunCaly(CollRunCaly):
         work_dir = Path(ip["task_name"])
         work_dir.mkdir(exist_ok=True, parents=True)
 
+        qhull_input = (
+            ip["qhull_input"].resolve()
+            if ip["qhull_input"] is not None
+            else ip["qhull_input"]
+        )
         step = ip["step"].resolve() if ip["step"] is not None else ip["step"]
         results = (
             ip["results"].resolve() if ip["results"] is not None else ip["results"]
@@ -998,6 +1003,9 @@ class MockedCollRunCaly(CollRunCaly):
         else:
             step_num = Path("step").read_text().strip()
             Path("step").write_text(f"{int(step_num)+1}")
+
+        if qhull_input is None:
+            Path("test_qconvex.in").write_text("")
 
         step_num = int(Path("step").read_text().strip())
 
@@ -1031,6 +1039,7 @@ class MockedCollRunCaly(CollRunCaly):
             "input_file": work_dir.joinpath(input_file.name),
             "results": work_dir.joinpath("results"),
             "step": work_dir.joinpath("step"),
+            "qhull_input": work_dir.joinpath("test_qconvex.in"),
         }
         return OPIO(ret_dict)
 

--- a/tests/op/test_collect_run_caly.py
+++ b/tests/op/test_collect_run_caly.py
@@ -44,7 +44,7 @@ class TestCollRunCaly(unittest.TestCase):
         self.input_file_path = Path("input_file")
         self.input_file_path.mkdir(parents=True, exist_ok=True)
         self.input_file = self.input_file_path.joinpath(calypso_input_file)
-        self.input_file.write_text("input.dat\nMaxStep=3\nVSC=T\n")
+        self.input_file.write_text("input.dat\nMaxStep=3\nVSC= T\n")
 
         self.step_file = self.input_file_path.joinpath("step")
         self.step_file.write_text("3")

--- a/tests/op/test_collect_run_caly.py
+++ b/tests/op/test_collect_run_caly.py
@@ -28,7 +28,7 @@ from dpgen2.constants import (
     calypso_input_file,
     calypso_log_name,
 )
-from dpgen2.op.collect_run_caly import CollRunCaly, get_max_step
+from dpgen2.op.collect_run_caly import CollRunCaly, get_value_from_inputdat
 from dpgen2.utils import (
     BinaryFileInput,
 )
@@ -44,7 +44,7 @@ class TestCollRunCaly(unittest.TestCase):
         self.input_file_path = Path("input_file")
         self.input_file_path.mkdir(parents=True, exist_ok=True)
         self.input_file = self.input_file_path.joinpath(calypso_input_file)
-        self.input_file.write_text("input.dat\nMaxStep=3\n")
+        self.input_file.write_text("input.dat\nMaxStep=3\nVSC=T\n")
 
         self.step_file = self.input_file_path.joinpath("step")
         self.step_file.write_text("3")
@@ -69,12 +69,15 @@ class TestCollRunCaly(unittest.TestCase):
         shutil.rmtree(Path(self.task_name), ignore_errors=True)
 
     def test_get_max_step(self):
-        max_step = get_max_step(self.input_file)
+        max_step, vsc = get_value_from_inputdat(self.input_file)
         self.assertTrue(max_step == 3)
+        self.assertTrue(vsc == True)
 
         temp_input_file = self.input_file_path.joinpath("temp_input_dat")
         temp_input_file.write_text("input.dat\n")
-        self.assertRaises(ValueError, get_max_step, temp_input_file)
+        max_step, vsc = get_value_from_inputdat(temp_input_file)
+        self.assertTrue(max_step == 0)
+        self.assertTrue(vsc == False)
 
     @patch("dpgen2.op.collect_run_caly.run_command")
     def test_step_st_maxstep_01(self, mocked_run):
@@ -109,6 +112,7 @@ class TestCollRunCaly(unittest.TestCase):
         self.assertEqual(out["input_file"], self.input_file)
         self.assertEqual(out["step"], Path(self.task_name) / "step")
         self.assertEqual(out["results"], Path(self.task_name) / "results")
+        self.assertEqual(out["qhull_input"], Path(self.task_name) / "test_qconvex.in")
         self.assertEqual(out["finished"], "false")
 
     @patch("dpgen2.op.collect_run_caly.run_command")

--- a/tests/test_caly_evo_step.py
+++ b/tests/test_caly_evo_step.py
@@ -61,7 +61,6 @@ from context import (
 from mocked_ops import (
     MockedCollRunCaly,
     MockedPrepRunDPOptim,
-    MockedRunLmp,
     mocked_numb_models,
 )
 
@@ -326,6 +325,7 @@ class TestCalyEvoStep(unittest.TestCase):
                 "results": None,
                 "step": None,
                 "opt_results_dir": None,
+                "qhull_input": None,
             },
         )
 
@@ -389,6 +389,7 @@ class TestCalyEvoStep(unittest.TestCase):
                 "results": None,
                 "step": None,
                 "opt_results_dir": None,
+                "qhull_input": None,
             },
         )
         wf = Workflow(name="caly-evo-step", host=default_host)

--- a/tests/test_prep_run_caly.py
+++ b/tests/test_prep_run_caly.py
@@ -51,20 +51,6 @@ try:
 except ModuleNotFoundError:
     # case of upload everything to argo, no context needed
     pass
-from context import (
-    default_host,
-    default_image,
-    skip_ut_with_dflow,
-    skip_ut_with_dflow_reason,
-    upload_python_packages,
-)
-from mocked_ops import (
-    MockedCollRunCaly,
-    MockedPrepRunDPOptim,
-    MockedRunCalyModelDevi,
-    mocked_numb_models,
-)
-
 from dpgen2.exploration.task import (
     BaseExplorationTaskGroup,
     ExplorationTask,
@@ -82,6 +68,20 @@ from dpgen2.superop.prep_run_calypso import (
     PrepRunCaly,
 )
 from dpgen2.utils.step_config import normalize as normalize_step_dict
+
+from .context import (
+    default_host,
+    default_image,
+    skip_ut_with_dflow,
+    skip_ut_with_dflow_reason,
+    upload_python_packages,
+)
+from .mocked_ops import (
+    MockedCollRunCaly,
+    MockedPrepRunDPOptim,
+    MockedRunCalyModelDevi,
+    mocked_numb_models,
+)
 
 default_config = normalize_step_dict(
     {


### PR DESCRIPTION
CALYPSO will propose structures with different chemical formula when using `VSC` mode. However, dpdata cannot parse a dump file containing frames with different chemical formula. To resolve this issue, frames are separated into different dump files based on the number of atoms in each frame.