### PR TITLE
Support keywords of pair_style for LmpTemplateTaskGroup

### DIFF
--- a/dpgen2/exploration/task/lmp_template_task_group.py
+++ b/dpgen2/exploration/task/lmp_template_task_group.py
@@ -43,14 +43,16 @@ class LmpTemplateTaskGroup(ConfSamplingTaskGroup):
         plm_template_fname: Optional[str] = None,
         revisions: dict = {},
         traj_freq: int = 10,
+        extra_pair_style_args: str = "",
     ) -> None:
         self.lmp_template = Path(lmp_template_fname).read_text().split("\n")
         self.revisions = revisions
         self.traj_freq = traj_freq
+        self.extra_pair_style_args = extra_pair_style_args
         self.lmp_set = True
         self.model_list = sorted([model_name_pattern % ii for ii in range(numb_models)])
         self.lmp_template = revise_lmp_input_model(
-            self.lmp_template, self.model_list, self.traj_freq
+            self.lmp_template, self.model_list, self.traj_freq, self.extra_pair_style_args
         )
         self.lmp_template = revise_lmp_input_dump(self.lmp_template, self.traj_freq)
         if plm_template_fname is not None:
@@ -138,16 +140,15 @@ def find_only_one_key(lmp_lines, key):
     return found[0]
 
 
-def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version="1"):
+def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, extra_pair_style_args="", deepmd_version="1"):
     idx = find_only_one_key(lmp_lines, ["pair_style", "deepmd"])
-    keywords = ""
-    for arg in lmp_lines[idx].split()[2:]:
-        keywords += " " + arg
+    if extra_pair_style_args:
+        extra_pair_style_args = " " + extra_pair_style_args
     graph_list = " ".join(task_model_list)
     lmp_lines[idx] = "pair_style      deepmd %s out_freq %d out_file model_devi.out%s" % (
         graph_list,
         trj_freq,
-        keywords,
+        extra_pair_style_args,
     )
     return lmp_lines
 

--- a/dpgen2/exploration/task/lmp_template_task_group.py
+++ b/dpgen2/exploration/task/lmp_template_task_group.py
@@ -140,10 +140,14 @@ def find_only_one_key(lmp_lines, key):
 
 def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, deepmd_version="1"):
     idx = find_only_one_key(lmp_lines, ["pair_style", "deepmd"])
+    keywords = ""
+    for arg in lmp_lines[idx].split()[2:]:
+        keywords += " " + arg
     graph_list = " ".join(task_model_list)
-    lmp_lines[idx] = "pair_style      deepmd %s out_freq %d out_file model_devi.out" % (
+    lmp_lines[idx] = "pair_style      deepmd %s out_freq %d out_file model_devi.out%s" % (
         graph_list,
         trj_freq,
+        keywords,
     )
     return lmp_lines
 

--- a/dpgen2/exploration/task/lmp_template_task_group.py
+++ b/dpgen2/exploration/task/lmp_template_task_group.py
@@ -52,7 +52,10 @@ class LmpTemplateTaskGroup(ConfSamplingTaskGroup):
         self.lmp_set = True
         self.model_list = sorted([model_name_pattern % ii for ii in range(numb_models)])
         self.lmp_template = revise_lmp_input_model(
-            self.lmp_template, self.model_list, self.traj_freq, self.extra_pair_style_args
+            self.lmp_template,
+            self.model_list,
+            self.traj_freq,
+            self.extra_pair_style_args,
         )
         self.lmp_template = revise_lmp_input_dump(self.lmp_template, self.traj_freq)
         if plm_template_fname is not None:
@@ -140,7 +143,9 @@ def find_only_one_key(lmp_lines, key):
     return found[0]
 
 
-def revise_lmp_input_model(lmp_lines, task_model_list, trj_freq, extra_pair_style_args="", deepmd_version="1"):
+def revise_lmp_input_model(
+    lmp_lines, task_model_list, trj_freq, extra_pair_style_args="", deepmd_version="1"
+):
     idx = find_only_one_key(lmp_lines, ["pair_style", "deepmd"])
     if extra_pair_style_args:
         extra_pair_style_args = " " + extra_pair_style_args

--- a/dpgen2/exploration/task/make_task_group_from_config.py
+++ b/dpgen2/exploration/task/make_task_group_from_config.py
@@ -100,6 +100,7 @@ def lmp_template_task_group_args():
     doc_plm_template_fname = "The file name of plumed input template"
     doc_revisions = "The revisions. Should be a dict providing the key - list of desired values pair. Key is the word to be replaced in the templates, and it may appear in both the lammps and plumed input templates. All values in the value list will be enmerated."
     doc_traj_freq = "The frequency of dumping configurations and thermodynamic states"
+    doc_extra_pair_style_args = "The extra arguments for pair_style"
 
     return [
         Argument("conf_idx", list, optional=False, doc=doc_conf_idx, alias=["sys_idx"]),
@@ -125,7 +126,7 @@ def lmp_template_task_group_args():
             doc=doc_plm_template_fname,
             alias=["plm_template", "plm"],
         ),
-        Argument("revisions", dict, optional=True, default={}),
+        Argument("revisions", dict, optional=True, default={}, doc=doc_revisions),
         Argument(
             "traj_freq",
             int,
@@ -134,6 +135,13 @@ def lmp_template_task_group_args():
             doc=doc_traj_freq,
             alias=["t_freq", "trj_freq", "trj_freq"],
         ),
+        Argument(
+            "extra_pair_style_args",
+            str,
+            optional=True,
+            default="",
+            doc=doc_extra_pair_style_args,
+        )
     ]
 
 

--- a/dpgen2/exploration/task/make_task_group_from_config.py
+++ b/dpgen2/exploration/task/make_task_group_from_config.py
@@ -141,7 +141,7 @@ def lmp_template_task_group_args():
             optional=True,
             default="",
             doc=doc_extra_pair_style_args,
-        )
+        ),
     ]
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the input handling to dynamically accommodate additional parameters for the `pair_style` command.
	- Added new documentation for parameters to improve usability and clarity in the task group configuration.

- **Bug Fixes**
	- Improved the handling of varying input scenarios by refining the functionality of the input model revision process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->