### PR TITLE
support spin

### DIFF
--- a/dpgen2/entrypoint/args.py
+++ b/dpgen2/entrypoint/args.py
@@ -212,6 +212,7 @@ def lmp_args():
         "Each task group is described in :ref:`the task group definition<task_group_sec>` "
     )
     doc_filters = "A list of configuration filters"
+    doc_lammps_input_file = "The template input file for LAMMPS simulation. Will pass it to dpdata to parse LAMMPS dump file in spin job."
 
     return [
         Argument(
@@ -258,6 +259,9 @@ def lmp_args():
             optional=True,
             default=[],
             doc=doc_filters,
+        ),
+        Argument(
+            "lammps_input_file", str, optional=True, default=None, doc=doc_lammps_input_file
         ),
     ]
 

--- a/dpgen2/entrypoint/args.py
+++ b/dpgen2/entrypoint/args.py
@@ -261,7 +261,11 @@ def lmp_args():
             doc=doc_filters,
         ),
         Argument(
-            "lammps_input_file", str, optional=True, default=None, doc=doc_lammps_input_file
+            "lammps_input_file",
+            str,
+            optional=True,
+            default=None,
+            doc=doc_lammps_input_file,
         ),
     ]
 

--- a/dpgen2/entrypoint/submit.py
+++ b/dpgen2/entrypoint/submit.py
@@ -81,8 +81,8 @@ from dpgen2.exploration.task import (
     CustomizedLmpTemplateTaskGroup,
     ExplorationStage,
     ExplorationTask,
-    LmpTemplateTaskGroup,
     LmpSpinTaskGroup,
+    LmpTemplateTaskGroup,
     NPTTaskGroup,
     caly_normalize,
     diffcsp_normalize,
@@ -319,7 +319,9 @@ def make_naive_exploration_scheduler_without_conf(config, explore_style):
     conv_style = convergence.pop("type")
     report = conv_styles[conv_style](**convergence)
     # trajectory render, the format of the output trajs are assumed to be lammps/dump
-    render = TrajRenderLammps(nopbc=output_nopbc,lammps_input_file=config["explore"]["lammps_input_file"])
+    render = TrajRenderLammps(
+        nopbc=output_nopbc, lammps_input_file=config["explore"]["lammps_input_file"]
+    )
     # selector
     selector = ConfSelectorFrames(
         render,
@@ -379,7 +381,11 @@ def make_lmp_naive_exploration_scheduler(config):
     # report
     conv_style = convergence.pop("type")
     report = conv_styles[conv_style](**convergence)
-    render = TrajRenderLammps(nopbc=output_nopbc, use_ele_temp=use_ele_temp, lammps_input_file=config["explore"]["lammps_input_file"])
+    render = TrajRenderLammps(
+        nopbc=output_nopbc,
+        use_ele_temp=use_ele_temp,
+        lammps_input_file=config["explore"]["lammps_input_file"],
+    )
     # selector
     selector = ConfSelectorFrames(
         render,

--- a/dpgen2/entrypoint/submit.py
+++ b/dpgen2/entrypoint/submit.py
@@ -82,6 +82,7 @@ from dpgen2.exploration.task import (
     ExplorationStage,
     ExplorationTask,
     LmpTemplateTaskGroup,
+    LmpSpinTaskGroup,
     NPTTaskGroup,
     caly_normalize,
     diffcsp_normalize,
@@ -318,7 +319,7 @@ def make_naive_exploration_scheduler_without_conf(config, explore_style):
     conv_style = convergence.pop("type")
     report = conv_styles[conv_style](**convergence)
     # trajectory render, the format of the output trajs are assumed to be lammps/dump
-    render = TrajRenderLammps(nopbc=output_nopbc)
+    render = TrajRenderLammps(nopbc=output_nopbc,lammps_input_file=config["explore"]["lammps_input_file"])
     # selector
     selector = ConfSelectorFrames(
         render,
@@ -378,7 +379,7 @@ def make_lmp_naive_exploration_scheduler(config):
     # report
     conv_style = convergence.pop("type")
     report = conv_styles[conv_style](**convergence)
-    render = TrajRenderLammps(nopbc=output_nopbc, use_ele_temp=use_ele_temp)
+    render = TrajRenderLammps(nopbc=output_nopbc, use_ele_temp=use_ele_temp, lammps_input_file=config["explore"]["lammps_input_file"])
     # selector
     selector = ConfSelectorFrames(
         render,

--- a/dpgen2/exploration/deviation/deviation_manager.py
+++ b/dpgen2/exploration/deviation/deviation_manager.py
@@ -19,6 +19,9 @@ class DeviManager(ABC):
     MAX_DEVI_F = "max_devi_f"
     MIN_DEVI_F = "min_devi_f"
     AVG_DEVI_F = "avg_devi_f"
+    MAX_DEVI_MF = "max_devi_mf"
+    MIN_DEVI_MF = "min_devi_mf"
+    AVG_DEVI_MF = "avg_devi_mf"
 
     def __init__(self) -> None:
         super().__init__()
@@ -32,6 +35,9 @@ class DeviManager(ABC):
             DeviManager.MAX_DEVI_F,
             DeviManager.MIN_DEVI_F,
             DeviManager.AVG_DEVI_F,
+            DeviManager.MAX_DEVI_MF,
+            DeviManager.MIN_DEVI_MF,
+            DeviManager.AVG_DEVI_MF,
         ), f"Error: unknown deviation name {name}"
 
     def add(self, name: str, deviation: np.ndarray) -> None:
@@ -64,7 +70,9 @@ class DeviManager(ABC):
             The name of the deviation. The name is restricted to
             (DeviManager.MAX_DEVI_V, DeviManager.MIN_DEVI_V,
              DeviManager.AVG_DEVI_V, DeviManager.MAX_DEVI_F,
-             DeviManager.MIN_DEVI_F, DeviManager.AVG_DEVI_F)
+             DeviManager.MIN_DEVI_F, DeviManager.AVG_DEVI_F,
+             DeviManager.MAX_DEVI_MF, DeviManager.MIN_DEVI_MF,
+             DeviManager.AVG_DEVI_MF)
         """
         self._check_name(name)
         self._check_data()

--- a/dpgen2/exploration/deviation/deviation_std.py
+++ b/dpgen2/exploration/deviation/deviation_std.py
@@ -65,6 +65,9 @@ class DeviManagerStd(DeviManager):
             DeviManager.MAX_DEVI_F,
             DeviManager.MIN_DEVI_F,
             DeviManager.AVG_DEVI_F,
+            DeviManager.MAX_DEVI_MF,
+            DeviManager.MIN_DEVI_MF,
+            DeviManager.AVG_DEVI_MF,
         )
         # check the length of model deviations
         frames = {}

--- a/dpgen2/exploration/render/traj_render_lammps.py
+++ b/dpgen2/exploration/render/traj_render_lammps.py
@@ -42,7 +42,7 @@ class TrajRenderLammps(TrajRender):
         self,
         nopbc: bool = False,
         use_ele_temp: int = 0,
-        lammps_input_file: str = None, # type: ignore
+        lammps_input_file: str = None,  # type: ignore
     ):
         self.nopbc = nopbc
         self.use_ele_temp = use_ele_temp
@@ -80,10 +80,10 @@ class TrajRenderLammps(TrajRender):
         model_devi.add(DeviManager.MIN_DEVI_F, dd[:, 5])  # type: ignore
         model_devi.add(DeviManager.AVG_DEVI_F, dd[:, 6])  # type: ignore
         # assume the 7-9 columns are for MF
-        if dd.shape[1] >= 10: # type: ignore
-            model_devi.add(DeviManager.MAX_DEVI_MF, dd[:, 7]) # type: ignore
-            model_devi.add(DeviManager.MIN_DEVI_MF, dd[:, 8]) # type: ignore
-            model_devi.add(DeviManager.AVG_DEVI_MF, dd[:, 9]) # type: ignore
+        if dd.shape[1] >= 10:  # type: ignore
+            model_devi.add(DeviManager.MAX_DEVI_MF, dd[:, 7])  # type: ignore
+            model_devi.add(DeviManager.MIN_DEVI_MF, dd[:, 8])  # type: ignore
+            model_devi.add(DeviManager.AVG_DEVI_MF, dd[:, 9])  # type: ignore
 
     def get_ele_temp(self, optional_outputs):
         ele_temp = []
@@ -139,7 +139,9 @@ class TrajRenderLammps(TrajRender):
                 else:
                     traj = trajs[ii]
                 # for spin job, need to read input file to get the key of the spin data
-                ss = dpdata.System(traj, fmt=traj_fmt, type_map=type_map, input_file=lammps_input_file)
+                ss = dpdata.System(
+                    traj, fmt=traj_fmt, type_map=type_map, input_file=lammps_input_file
+                )
                 ss.nopbc = self.nopbc
                 if ele_temp:
                     self.set_ele_temp(ss, ele_temp[ii])

--- a/dpgen2/exploration/render/traj_render_lammps.py
+++ b/dpgen2/exploration/render/traj_render_lammps.py
@@ -42,9 +42,14 @@ class TrajRenderLammps(TrajRender):
         self,
         nopbc: bool = False,
         use_ele_temp: int = 0,
+        lammps_input_file: str = None, # type: ignore
     ):
         self.nopbc = nopbc
         self.use_ele_temp = use_ele_temp
+        if lammps_input_file is not None:
+            self.lammps_input = Path(lammps_input_file).read_text()
+        else:
+            self.lammps_input = None
 
     def get_model_devi(
         self,
@@ -74,6 +79,11 @@ class TrajRenderLammps(TrajRender):
         model_devi.add(DeviManager.MAX_DEVI_F, dd[:, 4])  # type: ignore
         model_devi.add(DeviManager.MIN_DEVI_F, dd[:, 5])  # type: ignore
         model_devi.add(DeviManager.AVG_DEVI_F, dd[:, 6])  # type: ignore
+        # assume the 7-9 columns are for MF
+        if dd.shape[1] >= 10: # type: ignore
+            model_devi.add(DeviManager.MAX_DEVI_MF, dd[:, 7]) # type: ignore
+            model_devi.add(DeviManager.MIN_DEVI_MF, dd[:, 8]) # type: ignore
+            model_devi.add(DeviManager.AVG_DEVI_MF, dd[:, 9]) # type: ignore
 
     def get_ele_temp(self, optional_outputs):
         ele_temp = []
@@ -117,13 +127,19 @@ class TrajRenderLammps(TrajRender):
 
         traj_fmt = "lammps/dump"
         ms = dpdata.MultiSystems(type_map=type_map)
+        if self.lammps_input is not None:
+            lammps_input_file = "lammps_input.in"
+            Path(lammps_input_file).write_text(self.lammps_input)
+        else:
+            lammps_input_file = None
         for ii in range(ntraj):
             if len(id_selected[ii]) > 0:
                 if isinstance(trajs[ii], HDF5Dataset):
                     traj = StringIO(trajs[ii].get_data())  # type: ignore
                 else:
                     traj = trajs[ii]
-                ss = dpdata.System(traj, fmt=traj_fmt, type_map=type_map)
+                # for spin job, need to read input file to get the key of the spin data
+                ss = dpdata.System(traj, fmt=traj_fmt, type_map=type_map, input_file=lammps_input_file)
                 ss.nopbc = self.nopbc
                 if ele_temp:
                     self.set_ele_temp(ss, ele_temp[ii])

--- a/dpgen2/exploration/report/report_adaptive_lower.py
+++ b/dpgen2/exploration/report/report_adaptive_lower.py
@@ -175,8 +175,12 @@ class ExplorationReportAdaptiveLower(ExplorationReport):
         rate_candi_v_link = make_class_doc_link("rate_candi_v")
         numb_candi_mf_link = make_class_doc_link("numb_candi_mf")
         rate_candi_mf_link = make_class_doc_link("rate_candi_mf")
-        numb_candi_s = f"{numb_candi_f_link} or {numb_candi_v_link} or {numb_candi_mf_link}"
-        rate_candi_s = f"{rate_candi_f_link} or {rate_candi_v_link} or {rate_candi_mf_link}"
+        numb_candi_s = (
+            f"{numb_candi_f_link} or {numb_candi_v_link} or {numb_candi_mf_link}"
+        )
+        rate_candi_s = (
+            f"{rate_candi_f_link} or {rate_candi_v_link} or {rate_candi_mf_link}"
+        )
         level_f_hi_link = make_class_doc_link("level_f_hi")
         level_v_hi_link = make_class_doc_link("level_v_hi")
         level_mf_hi_link = make_class_doc_link("level_mf_hi")
@@ -232,7 +236,11 @@ class ExplorationReportAdaptiveLower(ExplorationReport):
                 "numb_candi_mf", int, optional=True, default=0, doc=doc_numb_candi_mf
             ),
             Argument(
-                "rate_candi_mf", float, optional=True, default=0.0, doc=doc_rate_candi_mf
+                "rate_candi_mf",
+                float,
+                optional=True,
+                default=0.0,
+                doc=doc_rate_candi_mf,
             ),
             Argument(
                 "n_checked_steps", int, optional=True, default=2, doc=doc_n_check_steps
@@ -286,9 +294,14 @@ class ExplorationReportAdaptiveLower(ExplorationReport):
         coll_mf = []
         # loop over trajs
         for ii in range(ntraj):
-            add_nframes, add_accur, add_failed, add_f, add_v, add_mf = self._record_one_traj(
-                ii, md_f[ii], md_v[ii], md_mf[ii]
-            )
+            (
+                add_nframes,
+                add_accur,
+                add_failed,
+                add_f,
+                add_v,
+                add_mf,
+            ) = self._record_one_traj(ii, md_f[ii], md_v[ii], md_mf[ii])
             self.nframes += add_nframes
             self.accur.update(add_accur)
             self.failed += add_failed
@@ -319,14 +332,14 @@ class ExplorationReportAdaptiveLower(ExplorationReport):
             self.level_v_lo = coll_v[-numb_candi_v][0]
         if not self.has_virial:
             self.level_v_lo = None
-            
+
         if numb_candi_mf == 0:
             self.level_mf_lo = self.level_mf_hi
         else:
             self.level_mf_lo = coll_mf[-numb_candi_mf][0]
         if not self.has_mf:
             self.level_mf_lo = None
-            
+
         if numb_candi_f == 0:
             self.level_f_lo = self.level_f_hi
         else:
@@ -385,7 +398,11 @@ class ExplorationReportAdaptiveLower(ExplorationReport):
         coll_v = []
         coll_mf = []
         for ii in range(nframes):
-            if md_f[ii] > self.level_f_hi or md_v[ii] > self.level_v_hi or md_mf[ii] > self.level_mf_hi:
+            if (
+                md_f[ii] > self.level_f_hi
+                or md_v[ii] > self.level_v_hi
+                or md_mf[ii] > self.level_mf_hi
+            ):
                 failed.append((tt, ii))
             else:
                 coll_f.append([md_f[ii], tt, ii])

--- a/dpgen2/exploration/report/report_trust_levels_base.py
+++ b/dpgen2/exploration/report/report_trust_levels_base.py
@@ -44,7 +44,9 @@ class ExplorationReportTrustLevels(ExplorationReport):
         self.conv_accuracy = conv_accuracy
         self.clear()
         self.v_level = (self.level_v_lo is not None) and (self.level_v_hi is not None)
-        self.mf_level = (self.level_mf_lo is not None) and (self.level_mf_hi is not None)
+        self.mf_level = (self.level_mf_lo is not None) and (
+            self.level_mf_hi is not None
+        )
         self.model_devi = None
 
         print_tuple = (
@@ -242,16 +244,18 @@ class ExplorationReportTrustLevels(ExplorationReport):
         set_mf_accu = set_full if nomagforce else set(id_mf_accu)
         set_mf_cand = set([]) if nomagforce else set(id_mf_cand)
         set_mf_fail = set([]) if nomagforce else set(id_mf_fail)
-        
+
         # check consistency
         assert set_full == set_f_accu | set_f_cand | set_f_fail
-        for accu, cand, fail in [[set_f_accu, set_f_cand, set_f_fail], 
-                                 [set_v_accu, set_v_cand, set_v_fail], 
-                                 [set_mf_accu, set_mf_cand, set_mf_fail]]:
+        for accu, cand, fail in [
+            [set_f_accu, set_f_cand, set_f_fail],
+            [set_v_accu, set_v_cand, set_v_fail],
+            [set_mf_accu, set_mf_cand, set_mf_fail],
+        ]:
             assert 0 == len(accu & cand)
             assert 0 == len(accu & fail)
             assert 0 == len(cand & fail)
-        
+
         # accu, cand, fail
         set_accu = set_f_accu & set_v_accu & set_mf_accu
         set_fail = set_f_fail | set_v_fail | set_mf_fail

--- a/dpgen2/exploration/report/report_trust_levels_max.py
+++ b/dpgen2/exploration/report/report_trust_levels_max.py
@@ -109,7 +109,9 @@ class ExplorationReportTrustLevelsMax(ExplorationReportTrustLevels):
 
         level_f_hi_link = make_class_doc_link("level_f_hi")
         level_v_hi_link = make_class_doc_link("level_v_hi")
+        level_mf_hi_link = make_class_doc_link("level_mf_hi")
         level_f_lo_link = make_class_doc_link("level_f_lo")
         level_v_lo_link = make_class_doc_link("level_v_lo")
+        level_mf_lo_link = make_class_doc_link("level_mf_lo")
         conv_accuracy_link = make_class_doc_link("conv_accuracy")
-        return f"The configurations with force model deviation between {level_f_lo_link}, {level_f_hi_link} or virial model deviation between {level_v_lo_link} and {level_v_hi_link} are treated as candidates (The virial model deviation check is optional). The configurations with maximal model deviation in the candidates are sent for FP calculations. If the ratio of accurate (below {level_f_lo_link} and {level_v_lo_link}) is higher then {conv_accuracy_link}, the stage is treated as converged."
+        return f"The configurations with force model deviation between {level_f_lo_link}, {level_f_hi_link} or virial model deviation between {level_v_lo_link} and {level_v_hi_link}, or magnetic force model deviation between {level_mf_lo_link} and {level_mf_hi_link}, are treated as candidates (The virial model deviation check is optional). The configurations with maximal model deviation in the candidates are sent for FP calculations. If the ratio of accurate (below {level_f_lo_link} and {level_v_lo_link}) is higher then {conv_accuracy_link}, the stage is treated as converged."

--- a/dpgen2/exploration/task/__init__.py
+++ b/dpgen2/exploration/task/__init__.py
@@ -10,11 +10,11 @@ from .customized_lmp_template_task_group import (
 from .diffcsp_task_group import (
     DiffCSPTaskGroup,
 )
-from .lmp_template_task_group import (
-    LmpTemplateTaskGroup,
-)
 from .lmp_spin_task_group import (
     LmpSpinTaskGroup,
+)
+from .lmp_template_task_group import (
+    LmpTemplateTaskGroup,
 )
 from .make_task_group_from_config import (
     caly_normalize,

--- a/dpgen2/exploration/task/__init__.py
+++ b/dpgen2/exploration/task/__init__.py
@@ -13,6 +13,9 @@ from .diffcsp_task_group import (
 from .lmp_template_task_group import (
     LmpTemplateTaskGroup,
 )
+from .lmp_spin_task_group import (
+    LmpSpinTaskGroup,
+)
 from .make_task_group_from_config import (
     caly_normalize,
     caly_task_group_args,

--- a/dpgen2/exploration/task/lmp_spin_task_group.py
+++ b/dpgen2/exploration/task/lmp_spin_task_group.py
@@ -41,7 +41,7 @@ class LmpSpinTaskGroup(ConfSamplingTaskGroup):
         numb_models: int,
         lmp_template_fname: str,
         plm_template_fname: Optional[str] = None,
-        revisions: dict = {}
+        revisions: dict = {},
     ) -> None:
         self.lmp_template = Path(lmp_template_fname).read_text().split("\n")
         self.revisions = revisions
@@ -103,6 +103,7 @@ class LmpSpinTaskGroup(ConfSamplingTaskGroup):
                 plm_cont,
             )
         return task
+
 
 def revise_by_keys(lmp_lines, keys, values):
     for kk, vv in zip(keys, values):  # type: ignore

--- a/dpgen2/exploration/task/lmp_spin_task_group.py
+++ b/dpgen2/exploration/task/lmp_spin_task_group.py
@@ -1,0 +1,111 @@
+import itertools
+import random
+from pathlib import (
+    Path,
+)
+from typing import (
+    List,
+    Optional,
+)
+
+from dpgen2.constants import (
+    lmp_conf_name,
+    lmp_input_name,
+    lmp_traj_name,
+    model_name_pattern,
+    plm_input_name,
+    plm_output_name,
+)
+
+from .conf_sampling_task_group import (
+    ConfSamplingTaskGroup,
+)
+from .lmp import (
+    make_lmp_input,
+)
+from .task import (
+    ExplorationTask,
+)
+
+
+class LmpSpinTaskGroup(ConfSamplingTaskGroup):
+    def __init__(
+        self,
+    ):
+        super().__init__()
+        self.lmp_set = False
+        self.plm_set = False
+
+    def set_lmp(
+        self,
+        numb_models: int,
+        lmp_template_fname: str,
+        plm_template_fname: Optional[str] = None,
+        revisions: dict = {}
+    ) -> None:
+        self.lmp_template = Path(lmp_template_fname).read_text().split("\n")
+        self.revisions = revisions
+        self.lmp_set = True
+        self.model_list = sorted([model_name_pattern % ii for ii in range(numb_models)])
+        if plm_template_fname is not None:
+            self.plm_template = Path(plm_template_fname).read_text().split("\n")
+            self.plm_set = True
+
+    def make_task(
+        self,
+    ) -> "LmpSpinTaskGroup":
+        if not self.conf_set:
+            raise RuntimeError("confs are not set")
+        if not self.lmp_set:
+            raise RuntimeError("Lammps SPIN template and revisions are not set")
+        # clear all existing tasks
+        self.clear()
+        confs = self._sample_confs()
+        templates = [self.lmp_template]
+        conts = self.make_cont(templates, self.revisions)
+        nconts = len(conts[0])
+        for cc, ii in itertools.product(confs, range(nconts)):  # type: ignore
+            self.add_task(self._make_lmp_task(cc, conts[0][ii]))
+        return self
+
+    def make_cont(
+        self,
+        templates: list,
+        revisions: dict,
+    ):
+        keys = revisions.keys()
+        prod_vv = [revisions[kk] for kk in keys]
+        ntemplate = len(templates)
+        ret = [[] for ii in range(ntemplate)]
+        for vv in itertools.product(*prod_vv):
+            for ii in range(ntemplate):
+                tt = templates[ii].copy()
+                ret[ii].append("\n".join(revise_by_keys(tt, keys, vv)))
+        return ret
+
+    def _make_lmp_task(
+        self,
+        conf: str,
+        lmp_cont: str,
+        plm_cont: Optional[str] = None,
+    ) -> ExplorationTask:
+        task = ExplorationTask()
+        task.add_file(
+            lmp_conf_name,
+            conf,
+        ).add_file(
+            lmp_input_name,
+            lmp_cont,
+        )
+        if plm_cont is not None:
+            task.add_file(
+                plm_input_name,
+                plm_cont,
+            )
+        return task
+
+def revise_by_keys(lmp_lines, keys, values):
+    for kk, vv in zip(keys, values):  # type: ignore
+        for ii in range(len(lmp_lines)):
+            lmp_lines[ii] = lmp_lines[ii].replace(kk, str(vv))
+    return lmp_lines

--- a/dpgen2/exploration/task/make_task_group_from_config.py
+++ b/dpgen2/exploration/task/make_task_group_from_config.py
@@ -22,6 +22,10 @@ from dpgen2.exploration.task.customized_lmp_template_task_group import (
 from dpgen2.exploration.task.lmp_template_task_group import (
     LmpTemplateTaskGroup,
 )
+from dpgen2.exploration.task.lmp_spin_task_group import (
+    LmpSpinTaskGroup,
+)
+
 from dpgen2.exploration.task.npt_task_group import (
     NPTTaskGroup,
 )
@@ -176,6 +180,43 @@ def lmp_template_task_group_args():
         ),
     ]
 
+def lmp_spin_task_group_args():
+    doc_lmp_template_fname = "The file name of lammps input template"
+    doc_plm_template_fname = "The file name of plumed input template"
+    doc_revisions = "The revisions. Should be a dict providing the key - list of desired values pair. Key is the word to be replaced in the templates, and it may appear in both the lammps and plumed input templates. All values in the value list will be enmerated."
+
+    return [
+        Argument("conf_idx", list, optional=False, doc=doc_conf_idx, alias=["sys_idx"]),
+        Argument(
+            "n_sample",
+            int,
+            optional=True,
+            default=None,
+            doc=doc_n_sample,
+        ),
+        Argument(
+            "lmp_template_fname",
+            str,
+            optional=False,
+            doc=doc_lmp_template_fname,
+            alias=["lmp_template", "lmp"],
+        ),
+        Argument(
+            "plm_template_fname",
+            str,
+            optional=True,
+            default=None,
+            doc=doc_plm_template_fname,
+            alias=["plm_template", "plm"],
+        ),
+        Argument(
+            "revisions", 
+            dict, 
+            optional=True, 
+            default={}, 
+            doc=doc_revisions,)
+    ]
+
 
 def customized_lmp_template_task_group_args():
     doc_input_lmp_tmpl_name = "The file name of lammps input template"
@@ -301,6 +342,12 @@ def variant_task_group():
                 "lmp-template",
                 dict,
                 lmp_template_task_group_args(),
+                doc=doc_lmp_template,
+            ),
+            Argument(
+                "lmp-spin",
+                dict,
+                lmp_spin_task_group_args(),
                 doc=doc_lmp_template,
             ),
             Argument(
@@ -628,6 +675,15 @@ def make_lmp_task_group_from_config(
         )
     elif config["type"] == "lmp-template":
         tgroup = LmpTemplateTaskGroup()
+        config.pop("type")
+        lmp_template = config.pop("lmp_template_fname")
+        tgroup.set_lmp(
+            numb_models,
+            lmp_template,
+            **config,
+        )
+    elif config["type"] == "lmp-spin":
+        tgroup = LmpSpinTaskGroup()
         config.pop("type")
         lmp_template = config.pop("lmp_template_fname")
         tgroup.set_lmp(

--- a/dpgen2/exploration/task/make_task_group_from_config.py
+++ b/dpgen2/exploration/task/make_task_group_from_config.py
@@ -19,13 +19,12 @@ from dpgen2.exploration.task.caly_task_group import (
 from dpgen2.exploration.task.customized_lmp_template_task_group import (
     CustomizedLmpTemplateTaskGroup,
 )
-from dpgen2.exploration.task.lmp_template_task_group import (
-    LmpTemplateTaskGroup,
-)
 from dpgen2.exploration.task.lmp_spin_task_group import (
     LmpSpinTaskGroup,
 )
-
+from dpgen2.exploration.task.lmp_template_task_group import (
+    LmpTemplateTaskGroup,
+)
 from dpgen2.exploration.task.npt_task_group import (
     NPTTaskGroup,
 )
@@ -180,6 +179,7 @@ def lmp_template_task_group_args():
         ),
     ]
 
+
 def lmp_spin_task_group_args():
     doc_lmp_template_fname = "The file name of lammps input template"
     doc_plm_template_fname = "The file name of plumed input template"
@@ -210,11 +210,12 @@ def lmp_spin_task_group_args():
             alias=["plm_template", "plm"],
         ),
         Argument(
-            "revisions", 
-            dict, 
-            optional=True, 
-            default={}, 
-            doc=doc_revisions,)
+            "revisions",
+            dict,
+            optional=True,
+            default={},
+            doc=doc_revisions,
+        ),
     ]
 
 

--- a/dpgen2/op/run_dp_train.py
+++ b/dpgen2/op/run_dp_train.py
@@ -415,12 +415,22 @@ class RunDPTrain(OP):
                 for v in odict["loss_dict"].values():
                     if isinstance(v, dict):
                         v["start_pref_e"] = config["init_model_start_pref_e"]
-                        v["start_pref_f"] = config["init_model_start_pref_f"]
                         v["start_pref_v"] = config["init_model_start_pref_v"]
+                        # for spin job, the key is "start_pref_fr" and "start_pref_fm"
+                        if config.get("spin", False):
+                            v["start_pref_fr"] = config["init_model_start_pref_f"]
+                            v["start_pref_fm"] = config["init_model_start_pref_fm"]
+                        else:
+                            v["start_pref_f"] = config["init_model_start_pref_f"]
+
             else:
                 odict["loss"]["start_pref_e"] = config["init_model_start_pref_e"]
-                odict["loss"]["start_pref_f"] = config["init_model_start_pref_f"]
                 odict["loss"]["start_pref_v"] = config["init_model_start_pref_v"]
+                if config.get("spin", False):
+                    odict["loss"]["start_pref_fr"] = config["init_model_start_pref_f"]
+                    odict["loss"]["start_pref_fm"] = config["init_model_start_pref_fm"]
+                else:
+                    odict["loss"]["start_pref_f"] = config["init_model_start_pref_f"]
             if major_version == "1":
                 odict["training"]["stop_batch"] = config["init_model_numb_steps"]
             elif major_version == "2":
@@ -509,6 +519,12 @@ class RunDPTrain(OP):
         doc_init_model_start_pref_f = (
             "The start force prefactor in loss when init-model"
         )
+        doc_init_model_start_pref_fm = (
+            "The start magnetic force prefactor in loss when init-model for spin job"
+        )
+        doc_spin = (
+            "If is a spin job"
+        )
         doc_init_model_start_pref_v = (
             "The start virial prefactor in loss when init-model"
         )
@@ -575,6 +591,20 @@ class RunDPTrain(OP):
                 optional=True,
                 default=100,
                 doc=doc_init_model_start_pref_f,
+            ),
+            Argument(
+                "init_model_start_pref_fm",
+                float,
+                optional=True,
+                default=100,
+                doc=doc_init_model_start_pref_fm,
+            ),
+            Argument(
+                "spin",
+                bool,
+                optional=True,
+                default=False,
+                doc=doc_spin,
             ),
             Argument(
                 "init_model_start_pref_v",

--- a/dpgen2/op/run_dp_train.py
+++ b/dpgen2/op/run_dp_train.py
@@ -522,9 +522,7 @@ class RunDPTrain(OP):
         doc_init_model_start_pref_fm = (
             "The start magnetic force prefactor in loss when init-model for spin job"
         )
-        doc_spin = (
-            "If is a spin job"
-        )
+        doc_spin = "If is a spin job"
         doc_init_model_start_pref_v = (
             "The start virial prefactor in loss when init-model"
         )

--- a/tests/exploration/test_devi_manager.py
+++ b/tests/exploration/test_devi_manager.py
@@ -31,11 +31,13 @@ class TestDeviManagerStd(unittest.TestCase):
             )
         )
         self.assertEqual(model_devi.get(DeviManager.MAX_DEVI_V), [None, None])
+        self.assertEqual(model_devi.get(DeviManager.MIN_DEVI_MF), [None, None])
 
         model_devi.clear()
         self.assertEqual(model_devi.ntraj, 0)
         self.assertEqual(model_devi.get(DeviManager.MAX_DEVI_F), [])
         self.assertEqual(model_devi.get(DeviManager.MAX_DEVI_V), [])
+        self.assertEqual(model_devi.get(DeviManager.MIN_DEVI_MF), [])
 
     def test_add_invalid_name(self):
         model_devi = DeviManagerStd()
@@ -72,6 +74,7 @@ class TestDeviManagerStd(unittest.TestCase):
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([1, 2, 3]))
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([4, 5, 6]))
         model_devi.add(DeviManager.MAX_DEVI_V, np.array([4, 5, 6]))
+        model_devi.add(DeviManager.MAX_DEVI_MF, np.array([7, 8, 9]))
 
         self.assertEqual(model_devi.ntraj, 2)
 
@@ -80,6 +83,13 @@ class TestDeviManagerStd(unittest.TestCase):
             "Error: the number of model deviation",
             model_devi.get,
             DeviManager.MAX_DEVI_V,
+        )
+        
+        self.assertRaisesRegex(
+            AssertionError,
+            "Error: the number of model deviation",
+            model_devi.get,
+            DeviManager.MAX_DEVI_MF,
         )
 
         model_devi = DeviManagerStd()
@@ -108,4 +118,22 @@ class TestDeviManagerStd(unittest.TestCase):
             f"Error: the number of frames in",
             model_devi.get,
             DeviManager.MAX_DEVI_V,
+        )
+        
+        model_devi = DeviManagerStd()
+        model_devi.add(DeviManager.MAX_DEVI_F, np.array([1, 2, 3]))
+        model_devi.add(DeviManager.MAX_DEVI_F, np.array([4, 5, 6]))
+        model_devi.add(DeviManager.MAX_DEVI_MF, np.array([1, 2, 3]))
+        model_devi.add(DeviManager.MAX_DEVI_MF, np.array([4, 5]))
+        self.assertRaisesRegex(
+            AssertionError,
+            f"Error: the number of frames in",
+            model_devi.get,
+            DeviManager.MAX_DEVI_F,
+        )
+        self.assertRaisesRegex(
+            AssertionError,
+            f"Error: the number of frames in",
+            model_devi.get,
+            DeviManager.MAX_DEVI_MF,
         )

--- a/tests/exploration/test_devi_manager.py
+++ b/tests/exploration/test_devi_manager.py
@@ -84,7 +84,7 @@ class TestDeviManagerStd(unittest.TestCase):
             model_devi.get,
             DeviManager.MAX_DEVI_V,
         )
-        
+
         self.assertRaisesRegex(
             AssertionError,
             "Error: the number of model deviation",
@@ -119,7 +119,7 @@ class TestDeviManagerStd(unittest.TestCase):
             model_devi.get,
             DeviManager.MAX_DEVI_V,
         )
-        
+
         model_devi = DeviManagerStd()
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([1, 2, 3]))
         model_devi.add(DeviManager.MAX_DEVI_F, np.array([4, 5, 6]))

--- a/tests/exploration/test_lmp_spin_task_group.py
+++ b/tests/exploration/test_lmp_spin_task_group.py
@@ -138,13 +138,18 @@ run             ${NSTEPS}
 """
 )
 
+
 class TestLmpSpinTaskGroup(unittest.TestCase):
     def setUp(self):
         self.lmp_template_fname = Path("lmp.template")
         self.lmp_template_fname.write_text(in_lmp_template)
         self.numb_models = 8
         self.confs = ["foo", "bar"]
-        self.lmp_rev_mat = {"V_NSTEPS": [1000], "V_TEMP": [50, 100], "V_MASS":[0.01, 0.1]}
+        self.lmp_rev_mat = {
+            "V_NSTEPS": [1000],
+            "V_TEMP": [50, 100],
+            "V_MASS": [0.01, 0.1],
+        }
         self.rev_empty = {}
 
     def tearDown(self):
@@ -154,9 +159,7 @@ class TestLmpSpinTaskGroup(unittest.TestCase):
         task_group = LmpSpinTaskGroup()
         task_group.set_conf(self.confs)
         task_group.set_lmp(
-            self.numb_models,
-            self.lmp_template_fname,
-            revisions=self.lmp_rev_mat
+            self.numb_models, self.lmp_template_fname, revisions=self.lmp_rev_mat
         )
         task_group.make_task()
         ngroup = len(task_group)
@@ -189,15 +192,11 @@ class TestLmpSpinTaskGroup(unittest.TestCase):
             )
             idx += 1
 
-    
-
     def test_lmp_empty(self):
         task_group = LmpSpinTaskGroup()
         task_group.set_conf(self.confs)
         task_group.set_lmp(
-            self.numb_models,
-            self.lmp_template_fname,
-            revisions=self.rev_empty
+            self.numb_models, self.lmp_template_fname, revisions=self.rev_empty
         )
         task_group.make_task()
         ngroup = len(task_group)
@@ -217,4 +216,3 @@ class TestLmpSpinTaskGroup(unittest.TestCase):
                 ee,
             )
             idx += 1
-

--- a/tests/exploration/test_lmp_spin_task_group.py
+++ b/tests/exploration/test_lmp_spin_task_group.py
@@ -1,0 +1,220 @@
+import itertools
+import os
+import textwrap
+import unittest
+from pathlib import (
+    Path,
+)
+from typing import (
+    List,
+    Set,
+)
+
+import numpy as np
+
+try:
+    from exploration.context import (
+        dpgen2,
+    )
+except ModuleNotFoundError:
+    # case of upload everything to argo, no context needed
+    pass
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+from dpgen2.constants import (
+    lmp_conf_name,
+    lmp_input_name,
+    plm_input_name,
+)
+from dpgen2.exploration.task import (
+    ExplorationStage,
+    LmpSpinTaskGroup,
+)
+
+in_lmp_template = textwrap.dedent(
+    """variable        NSTEPS          equal V_NSTEPS
+variable        THERMO_FREQ     equal 10
+variable        DUMP_FREQ       equal 10
+variable        TEMP            equal V_TEMP
+variable        PRES            equal 0.0
+variable        TAU_T           equal 0.100000
+variable        TAU_P           equal 0.500000
+variable        MASS            equal V_MASS
+
+units           metal
+boundary        p p p
+atom_style      atomic
+
+neighbor        1.0 bin
+
+box             tilt large
+read_data       conf.lmp
+change_box      all triclinic
+mass            1 27.000000
+mass            2 24.000000
+
+pair_style      deepspin model.000.pth model.001.pth model.002.pth model.003.pth out_freq ${THERMO_FREQ}
+pair_coeff      * *
+
+thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz
+thermo          ${THERMO_FREQ}
+
+dump            dpgen_dump
+
+velocity        all create ${TEMP} 826513
+fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P} mass ${MASS}
+
+timestep        0.002000
+run             
+
+compute         mag   all  spin
+compute         pe    all  pe
+compute         ke    all  ke
+compute         temp  all  temp
+compute         spin all property/atom sp spx spy spz fmx fmy fmz fx fy fz
+
+thermo          10
+thermo_style    custom step time v_magnorm temp v_tmag press etotal ke pe v_emag econserve
+
+dump            dpgen_dump all custom 10 traj.dump id type x y z c_spin[1] c_spin[2] c_spin[3] c_spin[4] c_spin[5] c_spin[6] c_spin[7] c_spin[8] c_spin[9] c_spin[10]
+dump_modify     dpgen_dump sort id
+
+run             ${NSTEPS}
+"""
+)
+
+expected_lmp_template = textwrap.dedent(
+    """variable        NSTEPS          equal V_NSTEPS
+variable        THERMO_FREQ     equal 10
+variable        DUMP_FREQ       equal 10
+variable        TEMP            equal V_TEMP
+variable        PRES            equal 0.0
+variable        TAU_T           equal 0.100000
+variable        TAU_P           equal 0.500000
+variable        MASS            equal V_MASS
+
+units           metal
+boundary        p p p
+atom_style      atomic
+
+neighbor        1.0 bin
+
+box             tilt large
+read_data       conf.lmp
+change_box      all triclinic
+mass            1 27.000000
+mass            2 24.000000
+
+pair_style      deepspin model.000.pth model.001.pth model.002.pth model.003.pth out_freq ${THERMO_FREQ}
+pair_coeff      * *
+
+thermo_style    custom step temp pe ke etotal press vol lx ly lz xy xz yz
+thermo          ${THERMO_FREQ}
+
+dump            dpgen_dump
+
+velocity        all create ${TEMP} 826513
+fix             1 all npt temp ${TEMP} ${TEMP} ${TAU_T} iso ${PRES} ${PRES} ${TAU_P} mass ${MASS}
+
+timestep        0.002000
+run             
+
+compute         mag   all  spin
+compute         pe    all  pe
+compute         ke    all  ke
+compute         temp  all  temp
+compute         spin all property/atom sp spx spy spz fmx fmy fmz fx fy fz
+
+thermo          10
+thermo_style    custom step time v_magnorm temp v_tmag press etotal ke pe v_emag econserve
+
+dump            dpgen_dump all custom 10 traj.dump id type x y z c_spin[1] c_spin[2] c_spin[3] c_spin[4] c_spin[5] c_spin[6] c_spin[7] c_spin[8] c_spin[9] c_spin[10]
+dump_modify     dpgen_dump sort id
+
+run             ${NSTEPS}
+"""
+)
+
+class TestLmpSpinTaskGroup(unittest.TestCase):
+    def setUp(self):
+        self.lmp_template_fname = Path("lmp.template")
+        self.lmp_template_fname.write_text(in_lmp_template)
+        self.numb_models = 8
+        self.confs = ["foo", "bar"]
+        self.lmp_rev_mat = {"V_NSTEPS": [1000], "V_TEMP": [50, 100], "V_MASS":[0.01, 0.1]}
+        self.rev_empty = {}
+
+    def tearDown(self):
+        os.remove(self.lmp_template_fname)
+
+    def test_lmp(self):
+        task_group = LmpSpinTaskGroup()
+        task_group.set_conf(self.confs)
+        task_group.set_lmp(
+            self.numb_models,
+            self.lmp_template_fname,
+            revisions=self.lmp_rev_mat
+        )
+        task_group.make_task()
+        ngroup = len(task_group)
+        self.assertEqual(
+            ngroup,
+            len(self.confs)
+            * len(self.lmp_rev_mat["V_NSTEPS"])
+            * len(self.lmp_rev_mat["V_TEMP"])
+            * len(self.lmp_rev_mat["V_MASS"]),
+        )
+
+        idx = 0
+        for cc, ii, jj, kk in itertools.product(
+            range(len(self.confs)),
+            range(len(self.lmp_rev_mat["V_NSTEPS"])),
+            range(len(self.lmp_rev_mat["V_TEMP"])),
+            range(len(self.lmp_rev_mat["V_MASS"])),
+        ):
+            ee = expected_lmp_template.split("\n")
+            ee[0] = ee[0].replace("V_NSTEPS", str(self.lmp_rev_mat["V_NSTEPS"][ii]))
+            ee[3] = ee[3].replace("V_TEMP", str(self.lmp_rev_mat["V_TEMP"][jj]))
+            ee[7] = ee[7].replace("V_MASS", str(self.lmp_rev_mat["V_MASS"][kk]))
+            self.assertEqual(
+                task_group[idx].files()[lmp_conf_name],
+                self.confs[cc],
+            )
+            self.assertEqual(
+                task_group[idx].files()[lmp_input_name].split("\n"),
+                ee,
+            )
+            idx += 1
+
+    
+
+    def test_lmp_empty(self):
+        task_group = LmpSpinTaskGroup()
+        task_group.set_conf(self.confs)
+        task_group.set_lmp(
+            self.numb_models,
+            self.lmp_template_fname,
+            revisions=self.rev_empty
+        )
+        task_group.make_task()
+        ngroup = len(task_group)
+        self.assertEqual(
+            ngroup,
+            len(self.confs),
+        )
+        idx = 0
+        for cc in range(len(self.confs)):
+            ee = expected_lmp_template.split("\n")
+            self.assertEqual(
+                task_group[idx].files()[lmp_conf_name],
+                self.confs[cc],
+            )
+            self.assertEqual(
+                task_group[idx].files()[lmp_input_name].split("\n"),
+                ee,
+            )
+            idx += 1
+

--- a/tests/exploration/test_report_adaptive_lower.py
+++ b/tests/exploration/test_report_adaptive_lower.py
@@ -365,8 +365,8 @@ class TestTrajsExplorationReport(unittest.TestCase):
         self.assertEqual(ter.candidate_ratio(), 3.0 / 18.0)
         self.assertEqual(ter.accurate_ratio(), 9.0 / 18.0)
         self.assertEqual(ter.failed_ratio(), 6.0 / 18.0)
-    
-    #### need modify   
+
+    #### need modify
     def test_v_mf(self):
         model_devi = DeviManagerStd()
         model_devi.add(
@@ -436,7 +436,7 @@ class TestTrajsExplorationReport(unittest.TestCase):
         self.assertEqual(ter.candidate_ratio(), 3.0 / 18.0)
         self.assertEqual(ter.accurate_ratio(), 9.0 / 18.0)
         self.assertEqual(ter.failed_ratio(), 6.0 / 18.0)
-    
+
     def test_args(self):
         input_dict = {
             "level_f_hi": 1.0,

--- a/tests/exploration/test_report_adaptive_lower.py
+++ b/tests/exploration/test_report_adaptive_lower.py
@@ -296,6 +296,147 @@ class TestTrajsExplorationReport(unittest.TestCase):
         self.assertEqual(ter.accurate_ratio(), 9.0 / 18.0)
         self.assertEqual(ter.failed_ratio(), 6.0 / 18.0)
 
+    def test_mf(self):
+        model_devi = DeviManagerStd()
+        model_devi.add(
+            DeviManager.MAX_DEVI_MF,
+            np.array([0.90, 0.10, 0.91, 0.11, 0.50, 0.53, 0.51, 0.52, 0.92]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_MF,
+            np.array([0.40, 0.20, 0.80, 0.81, 0.82, 0.21, 0.41, 0.22, 0.42]),
+        )
+
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.40, 0.20, 0.21, 0.80, 0.81, 0.53, 0.22, 0.82, 0.42]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.50, 0.90, 0.91, 0.92, 0.51, 0.52, 0.10, 0.11, 0.12]),
+        )
+
+        expected_fail_ = [[0, 2, 8], [2, 3, 4]]
+        expected_fail = set()
+        for idx, ii in enumerate(expected_fail_):
+            for jj in ii:
+                expected_fail.add((idx, jj))
+        expected_cand = set([(0, 6), (0, 7), (0, 5)])
+        expected_accu = set(
+            [(0, 1), (0, 3), (0, 4), (1, 0), (1, 1), (1, 5), (1, 6), (1, 7), (1, 8)]
+        )
+
+        ter = ExplorationReportAdaptiveLower(
+            level_f_hi=1.0,
+            numb_candi_f=0,
+            rate_candi_f=0.000,
+            level_mf_hi=0.76,
+            numb_candi_mf=3,
+            rate_candi_mf=0.001,
+            n_checked_steps=3,
+            conv_tolerance=0.001,
+        )
+        ter.record(model_devi)
+        self.assertEqual(ter.candi, expected_cand)
+        self.assertEqual(ter.accur, expected_accu)
+        self.assertEqual(set(ter.failed), expected_fail)
+
+        class MockedReport:
+            level_f_lo = 0
+            level_v_lo = 0
+            level_mf_lo = 0
+
+        mr = MockedReport()
+        mr.level_f_lo = 1.0
+        mr.level_v_lo = 0.51
+        mr.level_mf_lo = 0.51
+        self.assertFalse(ter.converged([mr]))
+        self.assertTrue(ter.converged([mr, mr]))
+        self.assertTrue(ter.converged([mr, mr, mr]))
+
+        picked = ter.get_candidate_ids(2)
+        npicked = 0
+        self.assertEqual(len(picked), 2)
+        for ii in range(2):
+            for jj in picked[ii]:
+                self.assertTrue((ii, jj) in expected_cand)
+                npicked += 1
+        self.assertEqual(npicked, 2)
+        self.assertEqual(ter.candidate_ratio(), 3.0 / 18.0)
+        self.assertEqual(ter.accurate_ratio(), 9.0 / 18.0)
+        self.assertEqual(ter.failed_ratio(), 6.0 / 18.0)
+    
+    #### need modify   
+    def test_v_mf(self):
+        model_devi = DeviManagerStd()
+        model_devi.add(
+            DeviManager.MAX_DEVI_V,
+            np.array([0.90, 0.10, 0.91, 0.11, 0.50, 0.53, 0.51, 0.52, 0.92]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_V,
+            np.array([0.40, 0.20, 0.80, 0.81, 0.82, 0.21, 0.41, 0.22, 0.42]),
+        )
+
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.40, 0.20, 0.21, 0.80, 0.81, 0.53, 0.22, 0.82, 0.42]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.50, 0.90, 0.91, 0.92, 0.51, 0.52, 0.10, 0.11, 0.12]),
+        )
+
+        expected_fail_ = [[0, 2, 8], [2, 3, 4]]
+        expected_fail = set()
+        for idx, ii in enumerate(expected_fail_):
+            for jj in ii:
+                expected_fail.add((idx, jj))
+        expected_cand = set([(0, 6), (0, 7), (0, 5)])
+        expected_accu = set(
+            [(0, 1), (0, 3), (0, 4), (1, 0), (1, 1), (1, 5), (1, 6), (1, 7), (1, 8)]
+        )
+
+        ter = ExplorationReportAdaptiveLower(
+            level_f_hi=1.0,
+            numb_candi_f=0,
+            rate_candi_f=0.000,
+            level_v_hi=0.76,
+            numb_candi_v=3,
+            rate_candi_v=0.001,
+            n_checked_steps=3,
+            conv_tolerance=0.001,
+        )
+        ter.record(model_devi)
+        self.assertEqual(ter.candi, expected_cand)
+        self.assertEqual(ter.accur, expected_accu)
+        self.assertEqual(set(ter.failed), expected_fail)
+
+        class MockedReport:
+            level_f_lo = 0
+            level_v_lo = 0
+            level_mf_lo = 0
+
+        mr = MockedReport()
+        mr.level_f_lo = 1.0
+        mr.level_v_lo = 0.51
+        mr.level_mf_lo = 0.51
+        self.assertFalse(ter.converged([mr]))
+        self.assertTrue(ter.converged([mr, mr]))
+        self.assertTrue(ter.converged([mr, mr, mr]))
+
+        picked = ter.get_candidate_ids(2)
+        npicked = 0
+        self.assertEqual(len(picked), 2)
+        for ii in range(2):
+            for jj in picked[ii]:
+                self.assertTrue((ii, jj) in expected_cand)
+                npicked += 1
+        self.assertEqual(npicked, 2)
+        self.assertEqual(ter.candidate_ratio(), 3.0 / 18.0)
+        self.assertEqual(ter.accurate_ratio(), 9.0 / 18.0)
+        self.assertEqual(ter.failed_ratio(), 6.0 / 18.0)
+    
     def test_args(self):
         input_dict = {
             "level_f_hi": 1.0,
@@ -315,4 +456,6 @@ class TestTrajsExplorationReport(unittest.TestCase):
         self.assertEqual(data["n_checked_steps"], 2)
         self.assertAlmostEqual(data["conv_tolerance"], 0.01)
         self.assertAlmostEqual(data["candi_sel_prob"], "uniform")
+        self.assertTrue(data["level_mf_hi"] is None)
+        self.assertEqual(data["numb_candi_mf"], 0)
         ExplorationReportAdaptiveLower(*data)

--- a/tests/exploration/test_report_trust_levels.py
+++ b/tests/exploration/test_report_trust_levels.py
@@ -36,7 +36,7 @@ class TestTrajsExplorationReport(unittest.TestCase):
         # behavior in frames selection when traj_cand <= max_nframes
         self.fv_selection_test(ExplorationReportTrustLevelsRandom)
         self.fv_selection_test(ExplorationReportTrustLevelsMax)
-        
+
         self.mf_selection_test(ExplorationReportTrustLevelsRandom)
         self.mf_selection_test(ExplorationReportTrustLevelsMax)
 
@@ -99,7 +99,7 @@ class TestTrajsExplorationReport(unittest.TestCase):
         self.assertEqual(ter.candidate_ratio(), 6.0 / 18.0)
         self.assertEqual(ter.accurate_ratio(), 2.0 / 18.0)
         self.assertEqual(ter.failed_ratio(), 10.0 / 18.0)
-    
+
     def mf_selection_test(self, exploration_report: ExplorationReportTrustLevels):
         model_devi = DeviManagerStd()
         model_devi.add(
@@ -127,7 +127,9 @@ class TestTrajsExplorationReport(unittest.TestCase):
         expected_fail = [set(ii) for ii in expected_fail]
         all_cand_sel = [(0, 6), (0, 5), (1, 8), (1, 6), (1, 0), (1, 5)]
 
-        ter = exploration_report(0.3, 0.6, level_mf_lo=0.3, level_mf_hi=0.6, conv_accuracy=0.9)
+        ter = exploration_report(
+            0.3, 0.6, level_mf_lo=0.3, level_mf_hi=0.6, conv_accuracy=0.9
+        )
         ter.record(model_devi)
         self.assertEqual(ter.traj_cand, expected_cand)
         self.assertEqual(ter.traj_accu, expected_accu)

--- a/tests/exploration/test_report_trust_levels.py
+++ b/tests/exploration/test_report_trust_levels.py
@@ -36,6 +36,9 @@ class TestTrajsExplorationReport(unittest.TestCase):
         # behavior in frames selection when traj_cand <= max_nframes
         self.fv_selection_test(ExplorationReportTrustLevelsRandom)
         self.fv_selection_test(ExplorationReportTrustLevelsMax)
+        
+        self.mf_selection_test(ExplorationReportTrustLevelsRandom)
+        self.mf_selection_test(ExplorationReportTrustLevelsMax)
 
         self.f_selection_test(ExplorationReportTrustLevelsRandom)
         self.f_selection_test(ExplorationReportTrustLevelsMax)
@@ -80,6 +83,51 @@ class TestTrajsExplorationReport(unittest.TestCase):
         all_cand_sel = [(0, 6), (0, 5), (1, 8), (1, 6), (1, 0), (1, 5)]
 
         ter = exploration_report(0.3, 0.6, 0.3, 0.6, conv_accuracy=0.9)
+        ter.record(model_devi)
+        self.assertEqual(ter.traj_cand, expected_cand)
+        self.assertEqual(ter.traj_accu, expected_accu)
+        self.assertEqual(ter.traj_fail, expected_fail)
+
+        picked = ter.get_candidate_ids(2)
+        npicked = 0
+        self.assertEqual(len(picked), 2)
+        for ii in range(2):
+            for jj in picked[ii]:
+                self.assertTrue(jj in expected_cand[ii])
+                npicked += 1
+        self.assertEqual(npicked, 2)
+        self.assertEqual(ter.candidate_ratio(), 6.0 / 18.0)
+        self.assertEqual(ter.accurate_ratio(), 2.0 / 18.0)
+        self.assertEqual(ter.failed_ratio(), 10.0 / 18.0)
+    
+    def mf_selection_test(self, exploration_report: ExplorationReportTrustLevels):
+        model_devi = DeviManagerStd()
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.90, 0.10, 0.91, 0.11, 0.50, 0.12, 0.51, 0.52, 0.92]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_F,
+            np.array([0.40, 0.20, 0.80, 0.81, 0.82, 0.21, 0.41, 0.22, 0.42]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_MF,
+            np.array([0.40, 0.20, 0.21, 0.80, 0.81, 0.41, 0.22, 0.82, 0.42]),
+        )
+        model_devi.add(
+            DeviManager.MAX_DEVI_MF,
+            np.array([0.50, 0.90, 0.91, 0.92, 0.51, 0.52, 0.10, 0.11, 0.12]),
+        )
+
+        expected_accu = [[1], [7]]
+        expected_cand = [[6, 5], [8, 6, 0, 5]]
+        expected_fail = [[0, 2, 3, 4, 7, 8], [1, 2, 3, 4]]
+        expected_accu = [set(ii) for ii in expected_accu]
+        expected_cand = [set(ii) for ii in expected_cand]
+        expected_fail = [set(ii) for ii in expected_fail]
+        all_cand_sel = [(0, 6), (0, 5), (1, 8), (1, 6), (1, 0), (1, 5)]
+
+        ter = exploration_report(0.3, 0.6, level_mf_lo=0.3, level_mf_hi=0.6, conv_accuracy=0.9)
         ter.record(model_devi)
         self.assertEqual(ter.traj_cand, expected_cand)
         self.assertEqual(ter.traj_accu, expected_accu)

--- a/tests/op/test_run_dp_train.py
+++ b/tests/op/test_run_dp_train.py
@@ -178,7 +178,7 @@ class TestRunDPTrain(unittest.TestCase):
                 "start_pref_v": 0.0,
             },
         }
-        
+
         self.expected_init_model_odict_v2_spin = {
             "training": {
                 "training_data": {
@@ -597,7 +597,12 @@ class TestRunDPTrain(unittest.TestCase):
         task_path = self.task_path
         Path(task_path).mkdir(exist_ok=True)
         idict_v2 = self.idict_v2.copy()
-        idict_v2["loss"] = {"start_pref_e": 0.1, "start_pref_v": 1, "start_pref_fr": 1, "start_pref_fm": 1}
+        idict_v2["loss"] = {
+            "start_pref_e": 0.1,
+            "start_pref_v": 1,
+            "start_pref_fr": 1,
+            "start_pref_fm": 1,
+        }
         with open(Path(task_path) / train_script_name, "w") as fp:
             json.dump(idict_v2, fp, indent=4)
         task_name = self.task_name
@@ -650,7 +655,7 @@ class TestRunDPTrain(unittest.TestCase):
             jdata = json.load(fp)
             print(jdata)
             self.assertDictEqual(jdata, self.expected_init_model_odict_v2_spin)
-    
+
     @patch("dpgen2.op.run_dp_train.run_command")
     def test_exec_v2_train_error(self, mocked_run):
         mocked_run.side_effect = [(1, "", "foo\n"), (0, "bar\n", "")]


### PR DESCRIPTION
Support the spin job:
1. In exploration/deviation add 3 new DeviManager parameters: MAX_DEVI_MF, MIN_DEVI_MF, AVG_DEVI_MF, to manager the deviation of magnetic force.
2. In report/AdaptiveLower and ExplorationReportTrustLevels, add magnetic force as the judgment index:
```
"convergence": {
            "type": "fixed-levels-max-select",
            "level_f_hi": 1,
            "level_mf_hi": 0.1,
            "level_f_lo": 0.1,
            "level_mf_lo": 0.01
        },
```

```
"convergence": {
            "type": "adaptive-lower",
            "level_f_hi": 1,
            "numb_candi_f": 200,
            "rate_candi_f": 0.1,
            "level_mf_hi": 1,
            "numb_candi_mf": 200,
            "rate_candi_mf": 0.1,
            "n_checked_steps": 2,
            "conv_tolerance": 0.01,
            "_comment": "all"
        },
```

3. In exploration/task add a new type "lmp-spin" for spin jobs, which is similar to "lmp-template" that need a template lammps input file.
4. Add option "lammps_input_file" in "explore", and this file is for dpdata to read the spin information from lammps dump file.
5. Add option "spin" in "train"/"config". For a spin training job, the name of the pre-factor for force is "limit_pref_fr" which is not same to the normal job that is "limit_pref_f", so we need this option to know if the job is for spin or not.

For a spin job, most of the contents of the submit config file are same as a normal job, except for:
1. For an init model job, set "spin" as "true" in "config", and set the value of "init_model_start_pref_fm" for the prefactor of magnetic force loss.
```
    "train": {
        "type": "dp",
        "init_models_paths": ["model1/model.ckpt.pt",
                              "model2/model.ckpt.pt",
                              "model3/model.ckpt.pt",
                              "model4/model.ckpt.pt"],
        "numb_models": 4,
        "template_script": "train.json",
        "config": {
            "command": "dp",
            "impl": "pytorch",
            "spin": true,
	        "init_model_with_finetune": false,
            "init_model_policy": "yes",
            "init_model_old_ratio": 0.8,
            "init_model_numb_steps": 600000,
            "init_model_start_lr": 1e-04,
            "init_model_start_pref_e": 0.25,
            "init_model_start_pref_f": 100,
            "init_model_start_pref_fm": 100,
            "init_model_start_pref_v": 100,
            "_comment": "all"
        }
    }
```
2. In explore/stage, set the type to be "lmp-spin", like:
```
"stages": [
            [
                {
                    "type": "lmp-spin",
                    "lmp_template_fname": "lmp.in",
                    "revisions": {
                        "V_TEMP": [50,100],
                        "V_MASS": [0.01,0.1,1.0],
                        "V_PRESS": [0.1,1.0]
                    },
                    "conf_idx": [
                        0
                    ],
                    "n_sample": 45
                }
            ]
        ],
```
A lammps template file may be like:
```
#========================================#
# initialization
#========================================#
units 		  metal
dimension 	  3
boundary 	  p p p
atom_style 	spin
read_data       conf.lmp
mass		1 55.845

velocity        all create V_TEMP SEED dist gaussian

#========================================#
# interatomic potentials
#========================================#
pair_style      deepspin model.000.pth model.001.pth model.002.pth model.003.pth out_freq 10
pair_coeff      * *

neighbor      1.0 bin
neigh_modify  every 10 check yes delay 20
fix           4 all npt temp V_TEMP V_TEMP 0.01 tri V_PRESS V_PRESS 0.1 mass V_MASS rand SEED
timestep      0.0001

#========================================#
# compute & output options
#========================================#
compute 	mag   all  spin
compute 	pe    all  pe
compute 	ke    all  ke
compute 	temp  all  temp
compute 	spin all property/atom sp spx spy spz fmx fmy fmz fx fy fz

thermo          10
thermo_style    custom step time v_magnorm temp v_tmag press etotal ke pe v_emag econserve
thermo_modify   line one format float %10.10g

dump            dpgen_dump all custom 10 traj.dump id type x y z c_spin[1] c_spin[2] c_spin[3] c_spin[4] c_spin[5] c_spin[6] c_spin[7] c_spin[8] c_spin[9] c_spin[10]
dump_modify     dpgen_dump sort id
dump_modify     dpgen_dump format float %10.8f

run             9000
```
Need replace "SEED" to a random number, the command may be like:"a=$RANDOM && sed -i \"s/SEED/$a/g\" in.lammps"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new deviation metrics and magnetic-force (MF) support across evaluation and reporting.
  * Added spin job mode for training with separate magnetic-force prefactor handling.

* **Documentation**
  * Updated help/argument text to expose MF and spin-related configuration options.

* **Tests**
  * Added and extended tests covering MF reporting and spin-mode training initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->