### PR TITLE
Run lammps extra outputs

### DIFF
--- a/dpgen2/op/run_lmp.py
+++ b/dpgen2/op/run_lmp.py
@@ -217,7 +217,7 @@ class RunLmp(OP):
         extra_outputs = []
         for fname in config["extra_output_files"]:
             extra_outputs += list(work_dir.glob(fname))
-        ret_dict["extra_outputs"] = extra_outputs
+        ret_dict["extra_outputs"] = extra_outputs  # type: ignore
         return OPIO(ret_dict)
 
     def get_model_devi(self, model_devi_file):

--- a/dpgen2/op/run_lmp.py
+++ b/dpgen2/op/run_lmp.py
@@ -83,7 +83,7 @@ class RunLmp(OP):
                 "model_devi": Artifact(Path),
                 "plm_output": Artifact(Path, optional=True),
                 "optional_output": Artifact(Path, optional=True),
-                "extra_outputs": Artifact(List[Path], optional=True),
+                "extra_outputs": Artifact(List[Path]),
             }
         )
 

--- a/dpgen2/op/run_lmp.py
+++ b/dpgen2/op/run_lmp.py
@@ -83,6 +83,7 @@ class RunLmp(OP):
                 "model_devi": Artifact(Path),
                 "plm_output": Artifact(Path, optional=True),
                 "optional_output": Artifact(Path, optional=True),
+                "extra_outputs": Artifact(List[Path], optional=True),
             }
         )
 
@@ -213,6 +214,10 @@ class RunLmp(OP):
         if ele_temp is not None:
             ret_dict["optional_output"] = work_dir / "job.json"
 
+        extra_outputs = []
+        for fname in config["extra_output_files"]:
+            extra_outputs += list(work_dir.glob(fname))
+        ret_dict["extra_outputs"] = extra_outputs
         return OPIO(ret_dict)
 
     def get_model_devi(self, model_devi_file):
@@ -226,6 +231,7 @@ class RunLmp(OP):
         doc_head = "Select a head from multitask"
         doc_use_ele_temp = "Whether to use electronic temperature, 0 for no, 1 for frame temperature, and 2 for atomic temperature"
         doc_use_hdf5 = "Use HDF5 to store trajs and model_devis"
+        doc_extra_output_files = "Extra output file names, support wildcards"
         return [
             Argument("command", str, optional=True, default="lmp", doc=doc_lmp_cmd),
             Argument(
@@ -255,6 +261,13 @@ class RunLmp(OP):
                 optional=True,
                 default=False,
                 doc=doc_use_hdf5,
+            ),
+            Argument(
+                "extra_output_files",
+                list,
+                optional=True,
+                default=[],
+                doc=doc_extra_output_files,
             ),
         ]
 

--- a/dpgen2/superop/prep_run_lmp.py
+++ b/dpgen2/superop/prep_run_lmp.py
@@ -76,6 +76,7 @@ class PrepRunLmp(Steps):
             "model_devis": OutputArtifact(),
             "plm_output": OutputArtifact(),
             "optional_outputs": OutputArtifact(),
+            "extra_outputs": OutputArtifact(),
         }
 
         super().__init__(
@@ -179,6 +180,7 @@ def _prep_run_lmp(
                     "model_devi",
                     "plm_output",
                     "optional_output",
+                    "extra_outputs",
                 ],
                 **template_slice_config,
             ),
@@ -217,5 +219,8 @@ def _prep_run_lmp(
     prep_run_steps.outputs.artifacts[
         "optional_outputs"
     ]._from = run_lmp.outputs.artifacts["optional_output"]
+    prep_run_steps.outputs.artifacts[
+        "extra_outputs"
+    ]._from = run_lmp.outputs.artifacts["extra_outputs"]
 
     return prep_run_steps

--- a/dpgen2/utils/download_dpgen2_artifacts.py
+++ b/dpgen2/utils/download_dpgen2_artifacts.py
@@ -63,7 +63,8 @@ op_download_setting = {
     "prep-run-explore": DownloadDefinition()
     .add_output("logs")
     .add_output("trajs")
-    .add_output("model_devis"),
+    .add_output("model_devis")
+    .add_output("extra_outputs"),
     "prep-run-fp": DownloadDefinition()
     .add_input("confs")
     .add_output("logs")

--- a/tests/mocked_ops.py
+++ b/tests/mocked_ops.py
@@ -424,6 +424,7 @@ class MockedRunLmp(RunLmp):
                 "log": work_dir / log,
                 "traj": work_dir / traj,
                 "model_devi": work_dir / model_devi,
+                "extra_outputs": [],
             }
         )
 

--- a/tests/op/test_run_lmp.py
+++ b/tests/op/test_run_lmp.py
@@ -126,6 +126,29 @@ class TestRunLmp(unittest.TestCase):
         ]
         mocked_run.assert_has_calls(calls)
 
+    def test_extra_outputs(self):
+        op = RunLmp()
+        out = op.execute(
+            OPIO(
+                {
+                    "config": {
+                        "command": "echo Hello > foo.txt",
+                        "extra_output_files": ["foo.txt"],
+                    },
+                    "task_name": self.task_name,
+                    "task_path": self.task_path,
+                    "models": self.models,
+                }
+            )
+        )
+        work_dir = Path(self.task_name)
+        # check output
+        self.assertEqual(out["extra_outputs"], [work_dir / "foo.txt"])
+        self.assertEqual(
+            (work_dir / "foo.txt").read_text().strip(),
+            "Hello -i in.lammps -log log.lammps",
+        )
+
 
 class TestRunLmpDist(unittest.TestCase):
     lmp_config = """variable        NSTEPS          equal 1000

--- a/tests/utils/test_dl_dpgen2_arti.py
+++ b/tests/utils/test_dl_dpgen2_arti.py
@@ -123,6 +123,11 @@ class TestDownloadDpgen2Artifact(unittest.TestCase):
                 path=Path("iter-000001/prep-run-explore/outputs"),
                 skip_exists=True,
             ),
+            mock.call(
+                "arti-extra_outputs",
+                path=Path("iter-000001/prep-run-explore/outputs"),
+                skip_exists=True,
+            ),
         ]
         self.assertEqual(len(mocked_dl.call_args_list), len(expected))
         for ii, jj in zip(mocked_dl.call_args_list, expected):
@@ -253,6 +258,11 @@ class TestDownloadDpgen2Artifact(unittest.TestCase):
                 path=Path("iter-000001/prep-run-explore/outputs"),
                 skip_exists=True,
             ),
+            mock.call(
+                "arti-extra_outputs",
+                path=Path("iter-000001/prep-run-explore/outputs"),
+                skip_exists=True,
+            ),
         ]
         self.assertEqual(len(mocked_dl.call_args_list), len(expected))
         for ii, jj in zip(mocked_dl.call_args_list, expected):
@@ -312,6 +322,11 @@ class TestDownloadDpgen2Artifact(unittest.TestCase):
             ),
             mock.call(
                 "arti-model_devis",
+                path=Path("iter-000001/prep-run-explore/outputs"),
+                skip_exists=True,
+            ),
+            mock.call(
+                "arti-extra_outputs",
                 path=Path("iter-000001/prep-run-explore/outputs"),
                 skip_exists=True,
             ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting and returning additional output files ("extra_outputs") in relevant operations.
  * Users can now specify extra output file patterns (including wildcards) to be captured after LAMMPS runs.

* **Tests**
  * Introduced a new test to verify correct handling and content of extra output files.
  * Extended existing tests to validate downloading of "extra_outputs" artifacts.

* **Chores**
  * Updated artifact download settings to include "extra_outputs" in the list of downloadable items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->