### PR TITLE
Patch non-repeative sampling "inv_pop_f"

### DIFF
--- a/dpgen2/exploration/report/report_adaptive_lower.py
+++ b/dpgen2/exploration/report/report_adaptive_lower.py
@@ -446,11 +446,13 @@ class ExplorationReportAdaptiveLower(ExplorationReport):
         self.candi_picked = [(ii[0], ii[1]) for ii in self.candi]
         if max_nframes is not None and max_nframes < len(self.candi_picked):
             prob = self._choice_prob_inv_pop_f(self.candi_picked)
-            ret = random.choices(
-                self.candi_picked,
-                weights=prob,
-                k=max_nframes,
+            indices = np.random.choice(
+                len(self.candi_picked),
+                size=max_nframes,
+                replace=False,
+                p=prob / np.sum(prob)
             )
+            ret = [self.candi_picked[i] for i in indices]
         else:
             ret = self.candi_picked
         return ret

--- a/dpgen2/exploration/report/report_adaptive_lower.py
+++ b/dpgen2/exploration/report/report_adaptive_lower.py
@@ -450,7 +450,7 @@ class ExplorationReportAdaptiveLower(ExplorationReport):
                 len(self.candi_picked),
                 size=max_nframes,
                 replace=False,
-                p=prob / np.sum(prob)
+                p=prob / np.sum(prob),
             )
             ret = [self.candi_picked[i] for i in indices]
         else:

--- a/tests/exploration/test_report_adaptive_lower.py
+++ b/tests/exploration/test_report_adaptive_lower.py
@@ -198,30 +198,32 @@ class TestTrajsExplorationReport(unittest.TestCase):
         )
 
         def faked_choices(
-            candi,
-            weights=None,
-            k=0,
+            a,  #numb_candi
+            size=None,  #numb_select
+            replace=False, # non-repeative sampling
+            p=None,  # normalized prob
         ):
             # hist: 2bins, 0.1-0.4 5candi, 0.4-0.7 7candi
             # only return those with mdf 0.1-0.4
-            self.assertEqual(len(weights), 12)
-            self.assertEqual(len(candi), 12)
-            ret = []
-            for ii in range(len(candi)):
-                tidx, fidx = candi[ii]
+            candi = ter.candi_picked 
+            self.assertEqual(a, 12)
+            self.assertEqual(len(p), 12)
+            ret_indices = []
+            for ii in range(a):
+                tidx, fidx = candi[ii] 
                 this_mdf = md_f[tidx][fidx]
                 if this_mdf < 0.4:
-                    self.assertAlmostEqual(weights[ii], 1.0 / 5.0)
-                    ret.append(candi[ii])
+                    self.assertAlmostEqual(p[ii], 0.1)  # 1/5 / 2.0
+                    ret_indices.append(ii)
                 else:
-                    self.assertAlmostEqual(weights[ii], 1.0 / 7.0)
-            return ret
+                    self.assertAlmostEqual(p[ii], 1.0 / 14.0)  # 1/7 / 2.0
+            return ret_indices
 
         ter.record(model_devi)
         self.assertEqual(ter.candi, expected_cand)
         self.assertEqual(ter.accur, expected_accu)
         self.assertEqual(set(ter.failed), expected_fail)
-        with mock.patch("random.choices", faked_choices):
+        with mock.patch("numpy.random.choice", faked_choices):
             picked = ter.get_candidate_ids(11)
         self.assertFalse(ter.converged([]))
         self.assertEqual(len(picked), 2)

--- a/tests/exploration/test_report_adaptive_lower.py
+++ b/tests/exploration/test_report_adaptive_lower.py
@@ -198,19 +198,19 @@ class TestTrajsExplorationReport(unittest.TestCase):
         )
 
         def faked_choices(
-            a,  #numb_candi
-            size=None,  #numb_select
-            replace=False, # non-repeative sampling
+            a,  # numb_candi
+            size=None,  # numb_select
+            replace=False,  # non-repeative sampling
             p=None,  # normalized prob
         ):
             # hist: 2bins, 0.1-0.4 5candi, 0.4-0.7 7candi
             # only return those with mdf 0.1-0.4
-            candi = ter.candi_picked 
+            candi = ter.candi_picked
             self.assertEqual(a, 12)
             self.assertEqual(len(p), 12)
             ret_indices = []
             for ii in range(a):
-                tidx, fidx = candi[ii] 
+                tidx, fidx = candi[ii]
                 this_mdf = md_f[tidx][fidx]
                 if this_mdf < 0.4:
                     self.assertAlmostEqual(p[ii], 0.1)  # 1/5 / 2.0


### PR DESCRIPTION
using non-repeative sampling instead of the original repeative sampling when using `"candi_sel_prob": "inv_pop_f"`.
`random.choices` -> `numpy.random.choice(replace=False)` 

The original behavior could take a large portion of repeated long-tail low-frequency smaples (the longer the tail, the worse the case), causing tens of percents of repeated downstream fp calculations, moreover amplifying the noise in labels from these high-force configurations.

The non-repeated sampling re-nomalizes the prob after screening out each picked sample

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved candidate selection process to ensure unique selections when limiting the number of candidates, preventing duplicates in the output.

* **Tests**
  * Updated tests to reflect changes in the candidate selection method and to ensure correct probability handling and uniqueness of selected candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->