### PR TITLE
fix: CP2KDATA logging pollution

### DIFF
--- a/dpgen2/entrypoint/main.py
+++ b/dpgen2/entrypoint/main.py
@@ -324,7 +324,21 @@ def parse_args(args: Optional[List[str]] = None):
 def main():
     #####################################
     # logging
-    logging.basicConfig(level=logging.INFO)
+    # Configure root logger for consistent logging format and level
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    formatter = logging.Formatter("[%(asctime)s] %(name)s - %(levelname)-7s - %(message)s")
+
+    if root_logger.hasHandlers():
+        # If handlers already exist (e.g., created by other modules), update their formatter and level
+        for handler in root_logger.handlers:
+            handler.setFormatter(formatter)
+            handler.setLevel(logging.INFO)
+        logging.info("Logging configuration has been updated.")
+    else:
+        # If no handlers exist, initialize logging with the desired format and level
+        logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(name)s - %(levelname)-7s - %(message)s")
+        logging.info("Logging system initialized.")
 
     args = parse_args()
     dict_args = vars(args)

--- a/dpgen2/entrypoint/main.py
+++ b/dpgen2/entrypoint/main.py
@@ -327,18 +327,16 @@ def main():
     # Configure root logger for consistent logging format and level
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
-    formatter = logging.Formatter("[%(asctime)s] %(name)s - %(levelname)-7s - %(message)s")
+    formatter = logging.Formatter("[%(asctime)s] %(name)s - %(levelname)-5s : %(message)s")
 
     if root_logger.hasHandlers():
         # If handlers already exist (e.g., created by other modules), update their formatter and level
         for handler in root_logger.handlers:
             handler.setFormatter(formatter)
             handler.setLevel(logging.INFO)
-        logging.info("Logging configuration has been updated.")
     else:
         # If no handlers exist, initialize logging with the desired format and level
-        logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(name)s - %(levelname)-7s - %(message)s")
-        logging.info("Logging system initialized.")
+        logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(name)s - %(levelname)-5s : %(message)s")
 
     args = parse_args()
     dict_args = vars(args)


### PR DESCRIPTION
the cp2kdata python package will pollution the logging information:
<img width="768" height="176" alt="ec3b1f08d6eef965b1b4ea8fd028ab80" src="https://github.com/user-attachments/assets/0d457bc5-a1c2-412e-b34d-ab13b9fc16d3" />

This pull corrects the root logging info, and change the style of root logging to separate from sub logging.