### PR TITLE
Bump minimum Python from 3.7 to 3.9

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,7 +250,7 @@ Located in `docs/` directory:
 
 ### CI/CD Pipeline
 GitHub Actions workflow (`.github/workflows/test.yml`):
-- Tests Python 3.8, 3.9, 3.10
+- Tests Python 3.9, 3.13
 - Runs full test suite with coverage
 - Validates formatting and import organization
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.13"]
 
     steps:
     - uses: actions/checkout@master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,11 @@ authors = [
 ]
 license = {file = "LICENSE"}
 classifiers = [
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]
 dependencies = [
@@ -26,7 +30,7 @@ dependencies = [
 	     'dpgui',
              'cp2kdata',
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 readme = "README.md"
 keywords = ["deep potential", "concurrent learning", "work flow"]
 


### PR DESCRIPTION
## Summary
- Bump `requires-python` from `>=3.7` to `>=3.9` — key dependencies (numpy, scipy) have already dropped 3.7/3.8 support
- Update CI test matrix from `[3.8, 3.9, 3.10]` to `[3.9, 3.13]`
- Add Python 3.9–3.13 classifiers to `pyproject.toml`
- Update `copilot-instructions.md` to reflect new CI matrix

## Test plan
- [ ] CI passes on Python 3.9 and 3.13
- [ ] `pip install dpgen2` works on Python 3.9+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum supported Python version from 3.7 to 3.9
  * Updated CI/CD testing pipeline to validate functionality on Python 3.9 and 3.13

<!-- end of auto-generated comment: release notes by coderabbit.ai -->