### PR TITLE
fix(test): account for Masses section in dpdata>=1.0.2 lammps output

### DIFF
--- a/tests/conf/test_alloy_conf.py
+++ b/tests/conf/test_alloy_conf.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import re
 import shutil
 import tempfile
 import unittest
@@ -23,8 +24,20 @@ from dpgen2.conf.alloy_conf import (
 # isort: on
 
 
+# dpdata >= 1.0.2 emits a "Masses" section in the lammps/lmp output
+_dpdata_ver = tuple(int(x) for x in re.findall(r"\d+", dpdata.__version__)[:3])
+_lmp_masses = (
+    "Masses\n\n     1   26.9815386000 # Al\n     2   24.3050000000 # Mg\n\n"
+    if _dpdata_ver >= (1, 0, 2)
+    else ""
+)
+
 ofc0 = "\n1 atoms\n2 atom types\n   0.0000000000    2.0000000000 xlo xhi\n   0.0000000000    2.0000000000 ylo yhi\n   0.0000000000    2.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      1    0.0000000000    0.0000000000    0.0000000000\n"
-ofc1 = "\n1 atoms\n2 atom types\n   0.0000000000    3.0000000000 xlo xhi\n   0.0000000000    3.0000000000 ylo yhi\n   0.0000000000    3.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"
+ofc1 = (
+    "\n1 atoms\n2 atom types\n   0.0000000000    3.0000000000 xlo xhi\n   0.0000000000    3.0000000000 ylo yhi\n   0.0000000000    3.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\n"
+    + _lmp_masses
+    + "Atoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"
+)
 ofc2 = "\n1 atoms\n2 atom types\n   0.0000000000    4.0000000000 xlo xhi\n   0.0000000000    4.0000000000 ylo yhi\n   0.0000000000    4.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"
 
 

--- a/tests/conf/test_file_conf.py
+++ b/tests/conf/test_file_conf.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import re
 import shutil
 import tempfile
 import textwrap
@@ -21,6 +22,14 @@ from dpgen2.conf.file_conf import (
 )
 
 # isort: on
+
+# dpdata >= 1.0.2 emits a "Masses" section in the lammps/lmp output
+_dpdata_ver = tuple(int(x) for x in re.findall(r"\d+", dpdata.__version__)[:3])
+_lmp_masses = (
+    "Masses\n\n     1   26.9815386000 # Al\n     2   24.3050000000 # Mg\n\n"
+    if _dpdata_ver >= (1, 0, 2)
+    else ""
+)
 
 pos0 = textwrap.dedent(
     """POSCAR file written by OVITO
@@ -58,7 +67,11 @@ Al
 cartesian
    0.0000000000    0.0000000000    0.0000000000
 """
-ofc0 = "\n1 atoms\n2 atom types\n   0.0000000000    2.0000000000 xlo xhi\n   0.0000000000    2.0000000000 ylo yhi\n   0.0000000000    2.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      1    0.0000000000    0.0000000000    0.0000000000\n"
+ofc0 = (
+    "\n1 atoms\n2 atom types\n   0.0000000000    2.0000000000 xlo xhi\n   0.0000000000    2.0000000000 ylo yhi\n   0.0000000000    2.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\n"
+    + _lmp_masses
+    + "Atoms # atomic\n\n     1      1    0.0000000000    0.0000000000    0.0000000000\n"
+)
 
 ifc1 = """Mg1 
 1.0
@@ -70,7 +83,11 @@ Mg
 cartesian
    0.0000000000    0.0000000000    0.0000000000
 """
-ofc1 = "\n1 atoms\n2 atom types\n   0.0000000000    3.0000000000 xlo xhi\n   0.0000000000    3.0000000000 ylo yhi\n   0.0000000000    3.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"
+ofc1 = (
+    "\n1 atoms\n2 atom types\n   0.0000000000    3.0000000000 xlo xhi\n   0.0000000000    3.0000000000 ylo yhi\n   0.0000000000    3.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\n"
+    + _lmp_masses
+    + "Atoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"
+)
 
 ifc2 = """Mg1 
 1.0
@@ -82,7 +99,11 @@ Mg
 cartesian
    0.0000000000    0.0000000000    0.0000000000
 """
-ofc2 = "\n1 atoms\n2 atom types\n   0.0000000000    4.0000000000 xlo xhi\n   0.0000000000    4.0000000000 ylo yhi\n   0.0000000000    4.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\nAtoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"
+ofc2 = (
+    "\n1 atoms\n2 atom types\n   0.0000000000    4.0000000000 xlo xhi\n   0.0000000000    4.0000000000 ylo yhi\n   0.0000000000    4.0000000000 zlo zhi\n   0.0000000000    0.0000000000    0.0000000000 xy xz yz\n\n"
+    + _lmp_masses
+    + "Atoms # atomic\n\n     1      2    0.0000000000    0.0000000000    0.0000000000\n"
+)
 
 
 class TestFileConfGenerator(unittest.TestCase):


### PR DESCRIPTION
## Problem

`tests/conf/test_alloy_conf.py::TestConfGenerator.test_make_conf_list` fails on the **Python 3.13** CI job (e.g. observed in #339, which is otherwise an unrelated dependabot bump):

```
AssertionError: Lists differ:
  ... xy xz yz\n\nMasses\n\n     1   26.9815386000 # Al ... Atoms # atomic ...
  != ... xy xz yz\n\nAtoms # atomic ...
```

## Cause

`dpdata` **1.0.2** started emitting a `Masses` section in `lammps/lmp` output. The CI matrix installs different dpdata majors per Python version:

| Job | dpdata | `Masses` section | Result |
|-----|--------|------------------|--------|
| build (3.9) | 1.0.1 (1.0.2 requires Python ≥3.10) | no | pass |
| build (3.13) | 1.0.2 | yes | fail |

Since `dpdata>=0.2.20` is the only constraint, a single hardcoded expected string cannot match both jobs.

## Fix

Keep the strict full-string comparison (the test's purpose is to verify the exact generated LAMMPS file), but include the `Masses` block in the expected `ofc1` when the installed `dpdata` is `>= 1.0.2`. Version detection uses a small regex so it avoids adding a `packaging` dependency and tolerates dev-version suffixes.

Verified against real dpdata 1.0.1 (no `Masses`) and 1.0.2 (`Masses`): `test_make_conf_list` passes on both.