### PR TITLE
fix(docker): use python:3.11-slim base for >=3.9 requirement

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -1,0 +1,27 @@
+# Build the Docker image on PRs without pushing, so base-image / dependency
+# breakage (e.g. a Python version mismatch) is caught before it reaches the
+# publish workflow on master. No registry login or secrets are needed because
+# nothing is pushed, which keeps this working for pull requests from forks.
+
+name: Test Docker image build
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'pyproject.toml'
+      - '.github/workflows/test-docker.yml'
+
+jobs:
+  build:
+    name: Build Docker image (no push)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6
+
+      - name: Build Docker image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: .
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.11-slim
 
+# git is required at build time: the version is derived from the repository
+# by setuptools_scm (see [tool.setuptools_scm] in pyproject.toml).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /data/dpgen2
 COPY ./ ./
 RUN pip install --no-cache-dir .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dptechnology/dflow:latest
+FROM python:3.11-slim
 
 WORKDIR /data/dpgen2
 COPY ./ ./


### PR DESCRIPTION
## Problem

The **Publish Docker image** workflow (`.github/workflows/pub-docker.yml`) fails on `master` after the minimum-Python bump to 3.9:

```
ERROR: Package 'dpgen2' requires a different Python: 3.8.20 not in '>=3.9'
```

The `Dockerfile` base `dptechnology/dflow:latest` ships **Python 3.8.20**, while `pyproject.toml` now declares `requires-python = ">=3.9"`, so `pip install .` aborts.

## Why it wasn't caught pre-merge

`pub-docker.yml` only triggers on `push: master` / `release` (no `pull_request`), and the unit-test workflow provisions Python via `actions/setup-python` rather than the Dockerfile — so nothing builds the image on PRs. The breakage only surfaces on the post-merge push to `master`.

## Fix

1. **`Dockerfile`** — switch the base image to `python:3.11-slim`.
   - `pydflow` is a declared dependency of dpgen2, so it is installed by `pip install .` and need not be baked into the base image (the old dflow base was effectively "python 3.8 + pydflow").
   - All install-time dependencies ship `cp311` manylinux wheels, so no source compilation is needed and the slim image is sufficient.
   - deepmd-kit is **not** a dpgen2 dependency and is never installed/built in this image; deepmd runs in separate task containers, so its C++/CMake build is unaffected by this base-image choice.

2. **`.github/workflows/test-docker.yml`** (new) — a build-only (`push: false`) workflow that builds the Dockerfile on pull requests touching `Dockerfile` / `pyproject.toml`. It requires no registry login or secrets, so it also works for fork PRs, and it closes the gap that let this breakage reach `master` unnoticed.

## Validation

The new build-only workflow runs on this PR (it touches both `Dockerfile` and the workflow file), so the base-image fix is validated here before merge.