### PR TITLE
fix: handle empty iter_data_new_exp in auto_prob generation

### DIFF
--- a/dpgen2/op/run_dp_train.py
+++ b/dpgen2/op/run_dp_train.py
@@ -236,22 +236,22 @@ class RunDPTrain(OP):
                 len_init = len(init_data)
             numb_old = len_init + len(iter_data_old_exp)
             numb_new = numb_old + len(iter_data_new_exp)
-            if numb_new > numb_old:
-                auto_prob_str = f"prob_sys_size; 0:{numb_old}:{old_ratio}; {numb_old}:{numb_new}:{1.-old_ratio:g}"
+            if numb_old > 0 and numb_new > numb_old:
+                auto_prob_str = f"prob_sys_size; 0:{numb_old}:{old_ratio}; {numb_old}:{numb_new}:{1.0 - old_ratio:g}"
             else:
-                # No new systems from the latest iteration.
-                # This can happen when FP labeling fails on all conformations
-                # and continue_on_success_ratio allows the workflow to proceed.
+                # Both weighted ranges must be non-empty. Either the workflow has
+                # no old data yet, or the latest iteration produced no new data.
                 # Fall back to uniform prob_sys_size to avoid generating an
-                # empty range (e.g. "0:2:0.6; 2:2:0.4") that crashes with
+                # empty range (e.g. "0:0:0.6" or "2:2:0.4") that crashes with
                 # "ValueError: probabilities do not sum to 1".
                 auto_prob_str = "prob_sys_size"
                 logging.warning(
-                    "No new systems from the latest iteration "
-                    "(iter_data_new_exp is empty, numb_old == numb_new == %d). "
+                    "Cannot build two non-empty auto_prob ranges "
+                    "(numb_old=%d, numb_new=%d). "
                     "Falling back to auto_prob='prob_sys_size'. "
-                    "Training will proceed with init_data + old iter_data only.",
+                    "Training will proceed with all available data.",
                     numb_old,
+                    numb_new,
                 )
 
         # update the input dict

--- a/dpgen2/op/run_dp_train.py
+++ b/dpgen2/op/run_dp_train.py
@@ -236,7 +236,23 @@ class RunDPTrain(OP):
                 len_init = len(init_data)
             numb_old = len_init + len(iter_data_old_exp)
             numb_new = numb_old + len(iter_data_new_exp)
-            auto_prob_str = f"prob_sys_size; 0:{numb_old}:{old_ratio}; {numb_old}:{numb_new}:{1.-old_ratio:g}"
+            if numb_new > numb_old:
+                auto_prob_str = f"prob_sys_size; 0:{numb_old}:{old_ratio}; {numb_old}:{numb_new}:{1.-old_ratio:g}"
+            else:
+                # No new systems from the latest iteration.
+                # This can happen when FP labeling fails on all conformations
+                # and continue_on_success_ratio allows the workflow to proceed.
+                # Fall back to uniform prob_sys_size to avoid generating an
+                # empty range (e.g. "0:2:0.6; 2:2:0.4") that crashes with
+                # "ValueError: probabilities do not sum to 1".
+                auto_prob_str = "prob_sys_size"
+                logging.warning(
+                    "No new systems from the latest iteration "
+                    "(iter_data_new_exp is empty, numb_old == numb_new == %d). "
+                    "Falling back to auto_prob='prob_sys_size'. "
+                    "Training will proceed with init_data + old iter_data only.",
+                    numb_old,
+                )
 
         # update the input dict
         train_dict = RunDPTrain.write_data_to_input_script(

--- a/tests/op/test_run_dp_train.py
+++ b/tests/op/test_run_dp_train.py
@@ -315,6 +315,46 @@ class TestRunDPTrain(unittest.TestCase):
         )
         self.assertTrue(do_init_model)
 
+    def test_auto_prob_empty_new_iter_data(self):
+        """Test that auto_prob falls back to 'prob_sys_size' when
+        iter_data_new_exp is empty (e.g., FP produced no labeled data).
+
+        Previously this would generate "prob_sys_size; 0:2:0.6; 2:2:0.4"
+        which crashes dp train with "probabilities do not sum to 1".
+        """
+        from dpgen2.op.run_dp_train import _expand_all_multi_sys_to_sys
+
+        # Create an empty directory to simulate iter_data with no systems
+        empty_iter = Path("empty_iter_data")
+        empty_iter.mkdir(exist_ok=True)
+
+        config = self.config.copy()
+        config["init_model_policy"] = "yes"
+        config["init_model_old_ratio"] = 0.6
+
+        # Simulate: iter_data = [empty_dir], expand gives []
+        iter_data_old_exp = []
+        iter_data_new_exp = _expand_all_multi_sys_to_sys([empty_iter])
+        self.assertEqual(iter_data_new_exp, [])
+
+        len_init = len(self.init_data)  # 2
+        numb_old = len_init + len(iter_data_old_exp)  # 2
+        numb_new = numb_old + len(iter_data_new_exp)  # 2
+
+        # The fix: when numb_new == numb_old, should NOT generate empty range
+        self.assertEqual(numb_new, numb_old)
+
+        # Verify the actual code path produces correct auto_prob
+        if numb_new > numb_old:
+            auto_prob_str = f"prob_sys_size; 0:{numb_old}:{config['init_model_old_ratio']}; {numb_old}:{numb_new}:{1.-config['init_model_old_ratio']:g}"
+        else:
+            auto_prob_str = "prob_sys_size"
+
+        self.assertEqual(auto_prob_str, "prob_sys_size")
+
+        # Cleanup
+        shutil.rmtree("empty_iter_data", ignore_errors=True)
+
     def test_update_input_dict_v1_init_model(self):
         odict = RunDPTrain.write_data_to_input_script(
             self.idict_v1,

--- a/tests/op/test_run_dp_train.py
+++ b/tests/op/test_run_dp_train.py
@@ -328,10 +328,13 @@ class TestRunDPTrain(unittest.TestCase):
         # Create an empty directory to simulate iter_data with no systems
         empty_iter = Path("empty_iter_data")
         empty_iter.mkdir(exist_ok=True)
+        self.addCleanup(shutil.rmtree, empty_iter, ignore_errors=True)
 
         # Create a task_path with input.json
         task_path = Path("input-auto-prob-test")
         task_path.mkdir(exist_ok=True)
+        self.addCleanup(shutil.rmtree, task_path, ignore_errors=True)
+        self.addCleanup(shutil.rmtree, Path("task-auto-prob"), ignore_errors=True)
         with open(task_path / train_script_name, "w") as fp:
             json.dump(self.idict_v2, fp, indent=4)
 
@@ -369,11 +372,6 @@ class TestRunDPTrain(unittest.TestCase):
         auto_prob = train_dict["training"]["training_data"]["auto_prob"]
         # Must be plain "prob_sys_size", NOT "prob_sys_size; 0:2:0.6; 2:2:0.4"
         self.assertEqual(auto_prob, "prob_sys_size")
-
-        # Cleanup
-        shutil.rmtree("empty_iter_data", ignore_errors=True)
-        shutil.rmtree("task-auto-prob", ignore_errors=True)
-        shutil.rmtree("input-auto-prob-test", ignore_errors=True)
 
     def test_auto_prob_empty_old_data(self):
         """The first labeled iteration falls back when no old data exists."""

--- a/tests/op/test_run_dp_train.py
+++ b/tests/op/test_run_dp_train.py
@@ -322,7 +322,9 @@ class TestRunDPTrain(unittest.TestCase):
         Previously this would generate "prob_sys_size; 0:2:0.6; 2:2:0.4"
         which crashes dp train with "probabilities do not sum to 1".
         """
-        from dpgen2.op.run_dp_train import _expand_all_multi_sys_to_sys
+        from dpgen2.op.run_dp_train import (
+            _expand_all_multi_sys_to_sys,
+        )
 
         # Create an empty directory to simulate iter_data with no systems
         empty_iter = Path("empty_iter_data")

--- a/tests/op/test_run_dp_train.py
+++ b/tests/op/test_run_dp_train.py
@@ -309,7 +309,7 @@ class TestRunDPTrain(unittest.TestCase):
 
     def test_decide_init_model_config_larger_than_yes(self):
         config = self.config.copy()
-        config["init_model_policy"] = f"old_data_larger_than:{self.old_data_size-1}"
+        config["init_model_policy"] = f"old_data_larger_than:{self.old_data_size - 1}"
         do_init_model = RunDPTrain.decide_init_model(
             config, self.init_model, self.init_data, self.iter_data
         )
@@ -359,12 +359,7 @@ class TestRunDPTrain(unittest.TestCase):
         op = RunDPTrain()
         # Mock run_command so dp train is not actually invoked
         with patch("dpgen2.op.run_dp_train.run_command", return_value=(0, "", "")):
-            try:
-                op.execute(ip)
-            except Exception:
-                # May fail on freeze/post-process; we only care about
-                # the generated training script at this point.
-                pass
+            op.execute(ip)
 
         # Read the generated training script and verify auto_prob
         script_path = Path("task-auto-prob") / train_script_name
@@ -379,6 +374,50 @@ class TestRunDPTrain(unittest.TestCase):
         shutil.rmtree("empty_iter_data", ignore_errors=True)
         shutil.rmtree("task-auto-prob", ignore_errors=True)
         shutil.rmtree("input-auto-prob-test", ignore_errors=True)
+
+    def test_auto_prob_empty_old_data(self):
+        """The first labeled iteration falls back when no old data exists."""
+        task_path = Path("input-auto-prob-empty-old")
+        task_path.mkdir(exist_ok=True)
+        with open(task_path / train_script_name, "w") as fp:
+            json.dump(self.idict_v2, fp, indent=4)
+
+        config = self.config.copy()
+        config["init_model_policy"] = "yes"
+        config["init_model_old_ratio"] = 0.6
+        task_name = "task-auto-prob-empty-old"
+
+        ip = OPIO(
+            {
+                "config": config,
+                "task_name": task_name,
+                "task_path": task_path,
+                "init_model": self.init_model,
+                "init_data": [],
+                "iter_data": [self.iter_data[0]],
+                "valid_data": None,
+                "optional_files": None,
+                "optional_parameter": {
+                    "mixed_type": False,
+                    "finetune_mode": "no",
+                },
+            }
+        )
+
+        try:
+            op = RunDPTrain()
+            with patch("dpgen2.op.run_dp_train.run_command", return_value=(0, "", "")):
+                op.execute(ip)
+
+            script_path = Path(task_name) / train_script_name
+            self.assertTrue(script_path.exists(), "Training script was not generated")
+            with open(script_path) as fp:
+                train_dict = json.load(fp)
+            auto_prob = train_dict["training"]["training_data"]["auto_prob"]
+            self.assertEqual(auto_prob, "prob_sys_size")
+        finally:
+            shutil.rmtree(task_name, ignore_errors=True)
+            shutil.rmtree(task_path, ignore_errors=True)
 
     def test_update_input_dict_v1_init_model(self):
         odict = RunDPTrain.write_data_to_input_script(

--- a/tests/op/test_run_dp_train.py
+++ b/tests/op/test_run_dp_train.py
@@ -321,41 +321,64 @@ class TestRunDPTrain(unittest.TestCase):
 
         Previously this would generate "prob_sys_size; 0:2:0.6; 2:2:0.4"
         which crashes dp train with "probabilities do not sum to 1".
-        """
-        from dpgen2.op.run_dp_train import (
-            _expand_all_multi_sys_to_sys,
-        )
 
+        This test exercises the real RunDPTrain.execute() code path with
+        a mocked run_command to verify the generated training script.
+        """
         # Create an empty directory to simulate iter_data with no systems
         empty_iter = Path("empty_iter_data")
         empty_iter.mkdir(exist_ok=True)
+
+        # Create a task_path with input.json
+        task_path = Path("input-auto-prob-test")
+        task_path.mkdir(exist_ok=True)
+        with open(task_path / train_script_name, "w") as fp:
+            json.dump(self.idict_v2, fp, indent=4)
 
         config = self.config.copy()
         config["init_model_policy"] = "yes"
         config["init_model_old_ratio"] = 0.6
 
-        # Simulate: iter_data = [empty_dir], expand gives []
-        iter_data_old_exp = []
-        iter_data_new_exp = _expand_all_multi_sys_to_sys([empty_iter])
-        self.assertEqual(iter_data_new_exp, [])
+        ip = OPIO(
+            {
+                "config": config,
+                "task_name": "task-auto-prob",
+                "task_path": task_path,
+                "init_model": self.init_model,
+                "init_data": self.init_data,
+                "iter_data": [empty_iter],
+                "valid_data": None,
+                "optional_files": None,
+                "optional_parameter": {
+                    "mixed_type": False,
+                    "finetune_mode": "no",
+                },
+            }
+        )
 
-        len_init = len(self.init_data)  # 2
-        numb_old = len_init + len(iter_data_old_exp)  # 2
-        numb_new = numb_old + len(iter_data_new_exp)  # 2
+        op = RunDPTrain()
+        # Mock run_command so dp train is not actually invoked
+        with patch("dpgen2.op.run_dp_train.run_command", return_value=(0, "", "")):
+            try:
+                op.execute(ip)
+            except Exception:
+                # May fail on freeze/post-process; we only care about
+                # the generated training script at this point.
+                pass
 
-        # The fix: when numb_new == numb_old, should NOT generate empty range
-        self.assertEqual(numb_new, numb_old)
-
-        # Verify the actual code path produces correct auto_prob
-        if numb_new > numb_old:
-            auto_prob_str = f"prob_sys_size; 0:{numb_old}:{config['init_model_old_ratio']}; {numb_old}:{numb_new}:{1.-config['init_model_old_ratio']:g}"
-        else:
-            auto_prob_str = "prob_sys_size"
-
-        self.assertEqual(auto_prob_str, "prob_sys_size")
+        # Read the generated training script and verify auto_prob
+        script_path = Path("task-auto-prob") / train_script_name
+        self.assertTrue(script_path.exists(), "Training script was not generated")
+        with open(script_path) as fp:
+            train_dict = json.load(fp)
+        auto_prob = train_dict["training"]["training_data"]["auto_prob"]
+        # Must be plain "prob_sys_size", NOT "prob_sys_size; 0:2:0.6; 2:2:0.4"
+        self.assertEqual(auto_prob, "prob_sys_size")
 
         # Cleanup
         shutil.rmtree("empty_iter_data", ignore_errors=True)
+        shutil.rmtree("task-auto-prob", ignore_errors=True)
+        shutil.rmtree("input-auto-prob-test", ignore_errors=True)
 
     def test_update_input_dict_v1_init_model(self):
         odict = RunDPTrain.write_data_to_input_script(


### PR DESCRIPTION
## Problem

When FP labeling fails on all conformations and `continue_on_success_ratio` allows the workflow to proceed, `iter_data` contains directory entries that expand to zero systems.

This causes `auto_prob` to generate `prob_sys_size; 0:2:0.6; 2:2:0.4` (empty range `2:2`) which crashes with `ValueError: probabilities do not sum to 1`.

## Fix

Guard with `if numb_new > numb_old` + fallback to plain `prob_sys_size` + warning log.

## Test

Added `test_auto_prob_empty_new_iter_data`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic training configuration when new systems or existing training data are unavailable.
  * Prevented invalid, empty probability ranges that could cause training failures.
  * Added a warning when ratio-based sampling cannot be applied and a safe fallback is selected.

* **Tests**
  * Added coverage for training iterations with empty new or existing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->